### PR TITLE
[codex] Split sparse morph geometry

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ motion [ラビットホール by mobiusP](https://www.nicovideo.jp/watch/sm42576
 | Append transform | ✅ PMX layer order |
 | WASM Parser | ✅ PMX / PMD with TypeScript fallback |
 | Physics (Ammo backend) | ✅ Uses Ammo.js |
-| Camera motion application | ❌ |
+| Camera motion application | ✅ Runtime sampling + Three.js helper, perspective/orthographic switch |
 | Three.js visual regression gates | ⚠️ Scripts exist; CI gates not wired |
 
 ## Acknowledgements
@@ -80,6 +80,47 @@ model.runtime?.setAnimation(animation, model.mesh);
 // Per frame.
 model.runtime?.tick(currentSeconds, model.mesh);
 ```
+
+## Usage - Camera Motion
+
+```ts
+import {
+  applyMmdCameraStateToThreeCamera,
+  sampleMmdCameraTrackInto
+} from "@yohawing/three-mmd-loader";
+
+const { animation } = await loader.loadAnimation(cameraVmdSource);
+const mmdFrameRate = 30; // Use 60 for MMD 60 FPS mode.
+const quantizeToMmdFrame = true; // Set false for unbounded/fractional-frame playback.
+const cameraStateScratch = {
+  distance: 0,
+  position: [0, 0, 0] as [number, number, number],
+  rotation: [0, 0, 0] as [number, number, number],
+  fov: 1,
+  perspective: true
+};
+
+// Per frame, using the selected MMD frame timeline.
+const frame = currentSeconds * mmdFrameRate;
+const cameraState = sampleMmdCameraTrackInto(
+  animation.cameraFrames,
+  quantizeToMmdFrame ? Math.floor(frame + 1e-6) : frame,
+  cameraStateScratch
+);
+if (cameraState) {
+  applyMmdCameraStateToThreeCamera(camera, cameraState);
+}
+```
+
+`applyMmdCameraStateToThreeCamera(...)` converts MMD camera coordinates for
+Three.js, including the MMD camera rotation convention, camera distance, roll,
+FOV, and perspective/orthographic frames. The example viewer exposes the same
+playback controls through URL query parameters:
+
+- `?mmdFrameRate=60` evaluates the MMD frame timeline at 60 FPS.
+- `?mmdFrameQuantize=false` keeps fractional frames for unbounded playback.
+- With no query parameters, the viewer defaults to 30 FPS and quantized MMD
+  frame playback.
 
 ## Usage - Pose (VPD)
 

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -30,7 +30,7 @@ English: [README.md](../README.md)
 | 付与変形 (append transform) | ✅ PMX layer 順 |
 | WASM Parser | ✅ PMX / PMD、TypeScript fallback あり |
 | 物理 (Ammo backend) | ✅ Ammo.jsを使用。  |
-| カメラモーション適用 | ❌ |
+| カメラモーション適用 | ✅ Runtime sampling + Three.js helper、perspective/orthographic 切替 |
 | Three.js 視覚回帰ゲート | ⚠️ script はあり / CI gate は未接続 |
 
 ## Acknowledgements
@@ -76,6 +76,46 @@ model.runtime?.setAnimation(animation, model.mesh);
 // 毎フレーム。
 model.runtime?.tick(currentSeconds, model.mesh);
 ```
+
+## 使い方 - カメラモーション
+
+```ts
+import {
+  applyMmdCameraStateToThreeCamera,
+  sampleMmdCameraTrackInto
+} from "@yohawing/three-mmd-loader";
+
+const { animation } = await loader.loadAnimation(cameraVmdSource);
+const mmdFrameRate = 30; // MMD の 60 FPS モードでは 60 を指定。
+const quantizeToMmdFrame = true; // 無制限 / 小数フレーム評価では false。
+const cameraStateScratch = {
+  distance: 0,
+  position: [0, 0, 0] as [number, number, number],
+  rotation: [0, 0, 0] as [number, number, number],
+  fov: 1,
+  perspective: true
+};
+
+// 毎フレーム。選択した MMD フレーム時間を渡す。
+const frame = currentSeconds * mmdFrameRate;
+const cameraState = sampleMmdCameraTrackInto(
+  animation.cameraFrames,
+  quantizeToMmdFrame ? Math.floor(frame + 1e-6) : frame,
+  cameraStateScratch
+);
+if (cameraState) {
+  applyMmdCameraStateToThreeCamera(camera, cameraState);
+}
+```
+
+`applyMmdCameraStateToThreeCamera(...)` は MMD カメラ座標を Three.js 用に
+変換します。MMD カメラの回転規約、距離、roll、FOV、perspective /
+orthographic frame の切替を含みます。example viewer では同じ再生設定を
+URL query で切り替えられます。
+
+- `?mmdFrameRate=60`: MMD フレーム時間を 60 FPS として評価。
+- `?mmdFrameQuantize=false`: 小数フレームを維持して無制限再生寄りに評価。
+- query なしでは 30 FPS、MMD フレームに quantize する再生が既定。
 
 ## 使い方 - ポーズ (VPD)
 

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -12,6 +12,7 @@ This checklist is the operator-facing release procedure for
   tag, not only from the final release-prep commit.
 - Confirm `package.json` `version` matches the intended release.
 - Confirm the working tree is clean.
+- Confirm the release branch is based on `develop`.
 - Confirm npm Trusted Publishing is configured for the GitHub `npm`
   environment.
 
@@ -55,19 +56,49 @@ git commit -m "chore(release): vX.Y.Z"
 Adjust the staged files if the release includes additional documentation or
 source changes.
 
-## 4. Tag
+Push the release-prep commit to `develop` before opening the release PR.
+
+```bash
+git push origin develop
+```
+
+## 4. Merge `develop` to `main`
+
+Open a pull request from `develop` to `main` before tagging. Do not publish from
+`develop`; the release tag must be created from the reviewed and merged `main`
+commit.
+
+```bash
+gh pr create --base main --head develop --title "chore(release): vX.Y.Z"
+```
+
+Review the PR, wait for CI, and merge it into `main`. Direct pushes to `main`
+may be blocked by repository rules; use the PR path even when the merge is a
+fast-forward.
+
+After merging, update the local `main` branch and confirm that `package.json`
+still matches the intended version.
+
+```bash
+git fetch origin
+git switch main
+git pull --ff-only origin main
+node -e "const p=require('./package.json'); if (p.version !== 'X.Y.Z') process.exit(1)"
+```
+
+## 5. Tag
 
 The release workflow requires the Git tag to match `package.json` exactly.
+Create the tag on `main` after the release PR has been reviewed and merged.
 
 ```bash
 git tag vX.Y.Z
-git push origin HEAD
 git push origin vX.Y.Z
 ```
 
 For example, `package.json` version `0.2.0` must be tagged as `v0.2.0`.
 
-## 5. GitHub Actions
+## 6. GitHub Actions
 
 The `Release` workflow runs on `v*.*.*` tags. It builds the package, validates
 tag/version consistency, creates the npm tarball, publishes to npm, and creates
@@ -84,7 +115,7 @@ Verify these workflow results:
 Manual dispatch is also available, but use tag-triggered releases for normal
 publishing so the GitHub Release is tied to the version tag.
 
-## 6. Post-release Verification
+## 7. Post-release Verification
 
 Verify the published npm artifact rather than only the local package:
 

--- a/examples/viewer/lib/background-loading.js
+++ b/examples/viewer/lib/background-loading.js
@@ -43,11 +43,7 @@ async function loadBackground(source, label, loaderFactory, entry) {
     const background = await loader.loadModel(source, { frustumCulled: false });
     state.currentBackground = background;
     syncMmdSpecularDirection(background.mesh.material, state.keyLight);
-    state.scene.add(
-      background.mesh,
-      ...(background.outlineMeshes ?? []),
-      ...(background.renderOrderMeshes ?? [])
-    );
+    state.scene.add(background.object);
     reportTextureDiagnostics(background);
     updateBackgroundSwitcher({
       ...entry,
@@ -70,11 +66,7 @@ export function clearBackground() {
     updateStageState();
     return;
   }
-  state.scene.remove(
-    state.currentBackground.mesh,
-    ...(state.currentBackground.outlineMeshes ?? []),
-    ...(state.currentBackground.renderOrderMeshes ?? [])
-  );
+  state.scene.remove(state.currentBackground.object);
   disposeModelResources(state.currentBackground);
   state.currentBackground = undefined;
   state.currentBackgroundEntries = [];

--- a/examples/viewer/lib/camera-loading.js
+++ b/examples/viewer/lib/camera-loading.js
@@ -1,7 +1,9 @@
 import { parseVmd } from "../../../dist/parser/index.js";
+import { sampleMmdCameraTrackInto } from "../../../dist/runtime/index.js";
+import { applyMmdCameraStateToThreeCamera } from "../../../dist/three/index.js";
 
 import { dom, setStatus, updatePlaybackDisplay, updateTransportState } from "./dom.js";
-import { currentMotionDurationSeconds, hasCurrentMotion } from "./state.js";
+import { currentMmdFrame, currentMotionDurationSeconds, hasCurrentMotion } from "./state.js";
 import { state } from "./state.js";
 import { labelFromUrl } from "./url-label.js";
 
@@ -54,6 +56,8 @@ export async function switchCameraEntry(entry) {
 export function clearCameraMotion() {
   state.currentCameraMotion = undefined;
   state.currentCameraEntries = [];
+  state.camera = state.perspectiveCamera;
+  state.controls.object = state.camera;
   updateCameraSwitcher();
   syncTimelineRangeToCurrentMotion();
   updateTransportState();
@@ -64,52 +68,25 @@ export function applyCameraMotion() {
   if (!cameraMotion || cameraMotion.frames.length === 0) {
     return;
   }
-  const frameNumber = state.elapsedSeconds * 30;
-  const frames = cameraMotion.frames;
-  let previous;
-  let next;
-  let t;
-  if (frameNumber <= frames[0].frame) {
-    cameraMotion.frameIndex = 0;
-    previous = frames[0];
-    next = frames[0];
-    t = 0;
-  } else {
-    if (cameraMotion.frameIndex >= frames.length || frames[cameraMotion.frameIndex].frame > frameNumber) {
-      cameraMotion.frameIndex = 0;
-    }
-    while (
-      cameraMotion.frameIndex + 1 < frames.length &&
-      frames[cameraMotion.frameIndex + 1].frame <= frameNumber
-    ) {
-      cameraMotion.frameIndex += 1;
-    }
-    previous = frames[cameraMotion.frameIndex];
-    next = frames[cameraMotion.frameIndex + 1] ?? previous;
-    t = previous === next ? 0 : (frameNumber - previous.frame) / Math.max(next.frame - previous.frame, 1);
+  const frameNumber = currentMmdFrame();
+  const sampled = sampleMmdCameraTrackInto(
+    cameraMotion.frames,
+    frameNumber,
+    state.cameraStateScratch,
+    cameraMotion.frameIndexHint
+  );
+  if (!sampled) {
+    return;
   }
-  const interpolation = next.interpolation;
-  const target = state.cameraTargetScratch;
-  const offset = state.cameraOffsetScratch;
-  const euler = state.cameraEulerScratch;
-  const distance = lerp(previous.distance, next.distance, interpolateBezier(interpolation?.distance, t));
-  target.set(
-    lerp(previous.position[0], next.position[0], interpolateBezier(interpolation?.positionX, t)),
-    lerp(previous.position[1], next.position[1], interpolateBezier(interpolation?.positionY, t)),
-    -lerp(previous.position[2], next.position[2], interpolateBezier(interpolation?.positionZ, t))
+  const activeCamera = applyMmdCameraStateToThreeCamera(
+    state.perspectiveCamera,
+    sampled,
+    state.cameraApplyOptions
   );
-  const rotationT = interpolateBezier(interpolation?.rotation, t);
-  euler.set(
-    -lerp(previous.rotation[0], next.rotation[0], rotationT),
-    -lerp(previous.rotation[1], next.rotation[1], rotationT),
-    lerp(previous.rotation[2], next.rotation[2], rotationT),
-    "YXZ"
-  );
-  offset.set(0, 0, -distance).applyEuler(euler);
-  state.camera.position.copy(target).add(offset);
-  state.camera.lookAt(target);
-  state.camera.fov = Math.max(lerp(previous.fov, next.fov, interpolateBezier(interpolation?.fov, t)), 1);
-  state.camera.updateProjectionMatrix();
+  if (state.camera !== activeCamera) {
+    state.camera = activeCamera;
+    state.controls.object = activeCamera;
+  }
 }
 
 async function loadCameraAnimation(animation, label, entry) {
@@ -120,8 +97,8 @@ async function loadCameraAnimation(animation, label, entry) {
   state.currentCameraMotion = {
     name: label,
     frames: animation.cameraFrames,
-    durationSeconds: Math.max((animation.metadata?.maxFrame ?? 0) / 30, 0),
-    frameIndex: 0
+    durationSeconds: Math.max((animation.metadata?.maxFrame ?? 0) / state.mmdFrameRate, 0),
+    frameIndexHint: { index: 0 }
   };
   updateCameraSwitcher({
     ...entry,
@@ -177,42 +154,4 @@ function updateCameraSwitcher(selectedEntry) {
   if (dom.cameraControl) {
     dom.cameraControl.hidden = state.currentCameraEntries.length === 0;
   }
-}
-
-function lerp(a, b, t) {
-  return a + (b - a) * t;
-}
-
-function interpolateBezier(curve, x) {
-  if (!curve) {
-    return x;
-  }
-  const x1 = curve[0];
-  const y1 = curve[1];
-  const x2 = curve[2];
-  const y2 = curve[3];
-  if (Math.abs(x1 - y1) < 1e-6 && Math.abs(x2 - y2) < 1e-6) {
-    return x;
-  }
-  let lower = 0;
-  let upper = 1;
-  let t = x;
-  for (let i = 0; i < 16; i += 1) {
-    const sampledX = cubicBezier(t, x1, x2);
-    if (Math.abs(sampledX - x) < 1e-5) {
-      break;
-    }
-    if (sampledX < x) {
-      lower = t;
-    } else {
-      upper = t;
-    }
-    t = (lower + upper) / 2;
-  }
-  return cubicBezier(t, y1, y2);
-}
-
-function cubicBezier(t, p1, p2) {
-  const inv = 1 - t;
-  return 3 * inv * inv * t * p1 + 3 * inv * t * t * p2 + t * t * t;
 }

--- a/examples/viewer/lib/model-loading.js
+++ b/examples/viewer/lib/model-loading.js
@@ -236,7 +236,7 @@ export async function switchFolderModel(modelFile) {
 export function clearModel(options = {}) {
   restoreDebugMaterials();
   if (state.currentModel) {
-    state.scene.remove(state.currentModel.mesh);
+    state.scene.remove(state.currentModel.object);
     disposeModelResources(state.currentModel);
   }
   state.currentModel = undefined;
@@ -261,11 +261,7 @@ export function clearModel(options = {}) {
 }
 
 function addModelToScene(model) {
-  state.scene.add(
-    model.mesh,
-    ...(model.outlineMeshes ?? []),
-    ...(model.renderOrderMeshes ?? [])
-  );
+  state.scene.add(model.object);
 }
 
 export function bindDropTarget() {

--- a/examples/viewer/lib/model-loading.js
+++ b/examples/viewer/lib/model-loading.js
@@ -473,7 +473,7 @@ export async function createModelLoader(extraOptions = {}) {
     geometryAwareAlpha: extraOptions.geometryAwareAlpha ?? true,
     runtime: {
       ...runtimeOptions,
-      frameRate: 30,
+      frameRate: state.mmdFrameRate,
       physics: "external",
       physicsBackend
     }

--- a/examples/viewer/lib/playback.js
+++ b/examples/viewer/lib/playback.js
@@ -1,7 +1,7 @@
 import { dom, setStatus, updatePlayToggle, updatePlaybackDisplay } from "./dom.js";
 import { hasActiveAudioSource, isAudioElement } from "./audio-loading.js";
 import { applyCameraMotion } from "./camera-loading.js";
-import { hasCurrentMotion, state } from "./state.js";
+import { currentMmdSeconds, hasCurrentMotion, state } from "./state.js";
 
 export function render() {
   const delta = state.clock.getDelta();
@@ -30,7 +30,7 @@ export function evaluateRuntime(options = {}) {
     syncAudioToMotionTime();
   }
   if (state.currentModel?.runtime) {
-    state.currentModel.runtime.tick(state.elapsedSeconds, {
+    state.currentModel.runtime.tick(currentMmdSeconds(), {
       mesh: state.currentModel.mesh,
       ik: options.ik ?? hasCurrentMotion(),
       physics: options.physics ?? (!state.isSeeking && state.elapsedSeconds > 0)

--- a/examples/viewer/lib/scene-setup.js
+++ b/examples/viewer/lib/scene-setup.js
@@ -14,7 +14,9 @@ export function setupScene() {
   state.renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
   state.renderer.setClearColor(0xffffff, 1);
   state.scene = new THREE.Scene();
-  state.camera = new THREE.PerspectiveCamera(22, 1, 0.01, 1000);
+  state.perspectiveCamera = new THREE.PerspectiveCamera(22, 1, 0.01, 1000);
+  state.orthographicCamera = new THREE.OrthographicCamera(-1, 1, 1, -1, 0.01, 1000);
+  state.camera = state.perspectiveCamera;
   state.camera.position.set(0, 1.1, 9);
   state.controls = new OrbitControls(state.camera, dom.canvas);
   state.controls.enableDamping = true;
@@ -36,19 +38,23 @@ export function fitCameraToObject(object) {
   const sphere = bounds.getBoundingSphere(new THREE.Sphere());
   const radius = Math.max(sphere.radius, 0.75);
   state.controls.target.copy(sphere.center);
-  state.camera.position.copy(sphere.center).add(new THREE.Vector3(0, radius * 0.15, radius * 5.2));
-  state.camera.near = Math.max(radius / 100, 0.01);
-  state.camera.far = Math.max(radius * 40, 100);
-  state.camera.updateProjectionMatrix();
+  state.camera = state.perspectiveCamera;
+  state.controls.object = state.camera;
+  state.perspectiveCamera.position.copy(sphere.center).add(new THREE.Vector3(0, radius * 0.15, radius * 5.2));
+  state.perspectiveCamera.near = Math.max(radius / 100, 0.01);
+  state.perspectiveCamera.far = Math.max(radius * 40, 100);
+  state.perspectiveCamera.updateProjectionMatrix();
   state.controls.update();
 }
 
 export function setDefaultCameraView() {
   state.controls.target.set(0, 0.9, 0);
-  state.camera.position.set(0, 1.1, 9);
-  state.camera.near = 0.01;
-  state.camera.far = 1000;
-  state.camera.updateProjectionMatrix();
+  state.camera = state.perspectiveCamera;
+  state.controls.object = state.camera;
+  state.perspectiveCamera.position.set(0, 1.1, 9);
+  state.perspectiveCamera.near = 0.01;
+  state.perspectiveCamera.far = 1000;
+  state.perspectiveCamera.updateProjectionMatrix();
   state.controls.update();
 }
 
@@ -56,7 +62,9 @@ export function resize() {
   const width = dom.canvas.clientWidth;
   const height = dom.canvas.clientHeight;
   state.renderer.setSize(width, height, false);
-  state.camera.aspect = width / Math.max(height, 1);
-  state.camera.updateProjectionMatrix();
+  state.cameraAspect = width / Math.max(height, 1);
+  state.perspectiveCamera.aspect = state.cameraAspect;
+  state.perspectiveCamera.updateProjectionMatrix();
+  state.orthographicCamera.updateProjectionMatrix();
   updateChromeHeights();
 }

--- a/examples/viewer/lib/state.js
+++ b/examples/viewer/lib/state.js
@@ -1,6 +1,7 @@
 import * as THREE from "three";
 
 import { ThreeMmdLoader } from "../../../dist/three/index.js";
+import { viewerConfig } from "./viewer-config.js";
 
 export const debugEnabled = new window.URLSearchParams(location.search).has("debug");
 
@@ -9,11 +10,14 @@ export const state = {
   activePhysicsBackend: undefined,
   ammoNamespace: undefined,
   ammoScriptLoadPromise: undefined,
-  animationLoader: new ThreeMmdLoader({ runtime: { frameRate: 30 } }),
+  animationLoader: new ThreeMmdLoader({ runtime: { frameRate: viewerConfig.mmdFrameRate } }),
   clock: new THREE.Clock(),
   renderer: undefined,
   scene: undefined,
   camera: undefined,
+  perspectiveCamera: undefined,
+  orthographicCamera: undefined,
+  cameraAspect: 1,
   controls: undefined,
   keyLight: undefined,
   currentModel: undefined,
@@ -26,6 +30,8 @@ export const state = {
   currentAudioEntries: [],
   currentBackgroundEntries: [],
   currentCameraEntries: [],
+  mmdFrameRate: viewerConfig.mmdFrameRate,
+  mmdFrameQuantize: viewerConfig.mmdFrameQuantize,
   assetLibrary: {
     presets: [],
     models: [],
@@ -55,6 +61,15 @@ export const state = {
   cameraTargetScratch: new THREE.Vector3(),
   cameraOffsetScratch: new THREE.Vector3(),
   cameraEulerScratch: new THREE.Euler(),
+  cameraQuaternionScratch: new THREE.Quaternion(),
+  cameraUpScratch: new THREE.Vector3(),
+  cameraStateScratch: {
+    distance: 0,
+    position: [0, 0, 0],
+    rotation: [0, 0, 0],
+    fov: 1,
+    perspective: true
+  },
   debugMaterialState: new Map(),
   restPoseAnimation: {
     kind: "vmd",
@@ -73,6 +88,20 @@ export const state = {
   }
 };
 
+state.cameraApplyOptions = {
+  target: state.cameraTargetScratch,
+  offset: state.cameraOffsetScratch,
+  euler: state.cameraEulerScratch,
+  quaternion: state.cameraQuaternionScratch,
+  up: state.cameraUpScratch,
+  get aspect() {
+    return state.cameraAspect;
+  },
+  get orthographicCamera() {
+    return state.orthographicCamera;
+  }
+};
+
 export function hasCurrentMotion() {
   return state.currentMotion?.animation !== undefined;
 }
@@ -83,6 +112,15 @@ export function currentMotionDurationSeconds() {
 }
 
 export function animationDurationSeconds(animation) {
-  return Math.max((animation.metadata?.maxFrame ?? 0) / 30, 0);
+  return Math.max((animation.metadata?.maxFrame ?? 0) / state.mmdFrameRate, 0);
+}
+
+export function currentMmdFrame() {
+  const frame = state.elapsedSeconds * state.mmdFrameRate;
+  return Math.max(state.mmdFrameQuantize ? Math.floor(frame + 1e-6) : frame, 0);
+}
+
+export function currentMmdSeconds() {
+  return currentMmdFrame() / state.mmdFrameRate;
 }
 

--- a/examples/viewer/lib/viewer-config.js
+++ b/examples/viewer/lib/viewer-config.js
@@ -1,0 +1,28 @@
+const query = new window.URLSearchParams(location.search);
+
+export const viewerConfig = {
+  mmdFrameRate: readPositiveNumber(query.get("mmdFrameRate"), 30),
+  mmdFrameQuantize: readBoolean(query.get("mmdFrameQuantize"), true)
+};
+
+function readPositiveNumber(value, fallback) {
+  if (value === null || value.trim() === "") {
+    return fallback;
+  }
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function readBoolean(value, fallback) {
+  if (value === null) {
+    return fallback;
+  }
+  const normalized = value.trim().toLowerCase();
+  if (["0", "false", "off", "no"].includes(normalized)) {
+    return false;
+  }
+  if (["1", "true", "on", "yes"].includes(normalized)) {
+    return true;
+  }
+  return fallback;
+}

--- a/scripts/serve-example-viewer.mjs
+++ b/scripts/serve-example-viewer.mjs
@@ -191,6 +191,13 @@ function createPresetEntries(cases, byExtension) {
     const modelUrl = dataUrlForFixturePath(modelPath);
     const motionPath = byExtension?.vmd?.[fixtureCase.motion?.key];
     const motionUrl = dataUrlForFixturePath(motionPath);
+    const backgroundUrl = dataUrlForFixturePath(
+      byExtension?.[fixtureCase.background?.extension]?.[fixtureCase.background?.key]
+    );
+    const cameraUrl = dataUrlForFixturePath(byExtension?.cameraVmd?.[fixtureCase.camera?.key]);
+    const audioUrl = dataUrlForFixturePath(
+      byExtension?.[fixtureCase.audio?.extension]?.[fixtureCase.audio?.key]
+    );
     if (modelUrl === undefined || motionUrl === undefined) {
       return [];
     }
@@ -198,7 +205,10 @@ function createPresetEntries(cases, byExtension) {
       id: fixtureCase.name,
       name: fixtureCase.name,
       modelUrl,
-      motionUrl
+      motionUrl,
+      ...(backgroundUrl ? { backgroundUrl } : {}),
+      ...(cameraUrl ? { cameraUrl } : {}),
+      ...(audioUrl ? { audioUrl } : {})
     }];
   });
 }

--- a/scripts/visual-regression/render-real-models.mjs
+++ b/scripts/visual-regression/render-real-models.mjs
@@ -385,7 +385,7 @@ function rendererHtml() {
               console.warn("Real-model texture diagnostic " + visualCase.name + ": " + diagnostic.code + " " + diagnostic.path);
             }
           }
-          scene.add(model.mesh, ...model.renderOrderMeshes, ...model.outlineMeshes);
+          scene.add(model.object);
 
           if (visualCase.motionUrl !== undefined) {
             const { animation } = await loader.loadAnimation(await fetchBytes(visualCase.motionUrl));
@@ -395,8 +395,8 @@ function rendererHtml() {
             model.runtime?.evaluate(visualCase.timeSeconds, { physics: false });
           }
 
-          model.mesh.updateMatrixWorld(true);
-          const camera = createCamera(visualCase.camera, model.mesh, config.render.resolution);
+          model.object.updateMatrixWorld(true);
+          const camera = createCamera(visualCase.camera, model.object, config.render.resolution);
           renderer.render(scene, camera);
           await new Promise(requestAnimationFrame);
           results.push({

--- a/src/runtime/animation.ts
+++ b/src/runtime/animation.ts
@@ -95,27 +95,58 @@ export function sampleMmdCameraTrack(
   frames: readonly VmdCameraFrame[],
   frame: number
 ): CameraState | undefined {
-  const pair = sampleFramePair(frames, frame);
-  if (!pair) {
+  return sampleMmdCameraTrackInto(frames, frame, {
+    distance: 0,
+    position: [0, 0, 0],
+    rotation: [0, 0, 0],
+    fov: 1,
+    perspective: true
+  });
+}
+
+export function sampleMmdCameraTrackInto(
+  frames: readonly VmdCameraFrame[],
+  frame: number,
+  target: CameraState,
+  hint?: { index: number }
+): CameraState | undefined {
+  if (frames.length === 0) {
     return undefined;
   }
-  const { previous, next, t } = pair;
+  let index = hint?.index ?? 0;
+  if (index >= frames.length || frames[index].frame > frame) {
+    index = 0;
+  }
+  let previous = frames[index] ?? frames[0];
+  let next = previous;
+  let t = 0;
+  if (frame < previous.frame) {
+    previous = frames[0];
+    next = previous;
+    index = 0;
+  } else {
+    while (index + 1 < frames.length && frames[index + 1].frame <= frame) {
+      index += 1;
+    }
+    previous = frames[index] ?? previous;
+    next = frames[index + 1] ?? previous;
+    t = interpolationRatio(previous.frame, next.frame, frame);
+    if (hint) {
+      hint.index = index;
+    }
+  }
   const interpolation = next.interpolation;
-  return {
-    distance: lerp(previous.distance, next.distance, interpolateBezier(interpolation?.distance, t)),
-    position: [
-      lerp(previous.position[0], next.position[0], interpolateBezier(interpolation?.positionX, t)),
-      lerp(previous.position[1], next.position[1], interpolateBezier(interpolation?.positionY, t)),
-      lerp(previous.position[2], next.position[2], interpolateBezier(interpolation?.positionZ, t))
-    ],
-    rotation: [
-      lerp(previous.rotation[0], next.rotation[0], interpolateBezier(interpolation?.rotation, t)),
-      lerp(previous.rotation[1], next.rotation[1], interpolateBezier(interpolation?.rotation, t)),
-      lerp(previous.rotation[2], next.rotation[2], interpolateBezier(interpolation?.rotation, t))
-    ],
-    fov: lerp(previous.fov, next.fov, interpolateBezier(interpolation?.fov, t)),
-    perspective: t < 1 ? previous.perspective : next.perspective
-  };
+  target.distance = lerp(previous.distance, next.distance, interpolateBezier(interpolation?.distance, t));
+  target.position[0] = lerp(previous.position[0], next.position[0], interpolateBezier(interpolation?.positionX, t));
+  target.position[1] = lerp(previous.position[1], next.position[1], interpolateBezier(interpolation?.positionY, t));
+  target.position[2] = lerp(previous.position[2], next.position[2], interpolateBezier(interpolation?.positionZ, t));
+  const rotationT = interpolateBezier(interpolation?.rotation, t);
+  target.rotation[0] = lerp(previous.rotation[0], next.rotation[0], rotationT);
+  target.rotation[1] = lerp(previous.rotation[1], next.rotation[1], rotationT);
+  target.rotation[2] = lerp(previous.rotation[2], next.rotation[2], rotationT);
+  target.fov = lerp(previous.fov, next.fov, interpolateBezier(interpolation?.fov, t));
+  target.perspective = t < 1 ? previous.perspective : next.perspective;
+  return target;
 }
 
 export function sampleMmdLightTrack(
@@ -162,7 +193,7 @@ function sampleFramePair<T extends { readonly frame: number }>(
       return {
         previous,
         next,
-        t: (frame - previous.frame) / Math.max(next.frame - previous.frame, 1)
+          t: interpolationRatio(previous.frame, next.frame, frame)
       };
     }
     previous = next;
@@ -270,7 +301,7 @@ function samplePackedBoneTrack(track: VmdBoneTrack, frame: number): VmdBoneFrame
     }
     if (frame < nextFrame) {
       const previousFrame = frames[previousIndex] ?? 0;
-      const t = (frame - previousFrame) / Math.max(nextFrame - previousFrame, 1);
+      const t = interpolationRatio(previousFrame, nextFrame, frame);
       const interpolation = readPackedBoneInterpolation(track, index);
       const previous = readPackedBoneFrame(track, previousIndex, previousFrame);
       const next = readPackedBoneFrame(track, index, nextFrame);
@@ -306,7 +337,7 @@ function samplePackedMorphTrack(track: VmdMorphTrack, frame: number): number {
     }
     if (frame < nextFrame) {
       const previousFrame = frames[previousIndex] ?? 0;
-      const t = (frame - previousFrame) / Math.max(nextFrame - previousFrame, 1);
+      const t = interpolationRatio(previousFrame, nextFrame, frame);
       return lerp(track.weights[previousIndex] ?? 0, track.weights[index] ?? 0, t);
     }
     previousIndex = index;
@@ -359,3 +390,14 @@ function readPackedCurve(values: Float32Array, offset: number): [number, number,
 }
 
 export { findBoneTrack, isMmdAnimation, sampleBoneTrack, sampleFramePair, sampleMorphTrack };
+
+function interpolationRatio(previousFrame: number, nextFrame: number, frame: number): number {
+  const span = nextFrame - previousFrame;
+  if (span <= 0) {
+    return 0;
+  }
+  if (span <= 1) {
+    return frame >= nextFrame ? 1 : 0;
+  }
+  return (frame - previousFrame) / span;
+}

--- a/src/runtime/core.ts
+++ b/src/runtime/core.ts
@@ -27,6 +27,10 @@ export class DefaultMmdRuntime implements MmdRuntime {
   private previousEvaluateSeconds: number | undefined;
   private physicsDisabled = false;
   private preparedIkChains: CcdIkPreparedChain[] = [];
+  private readonly activeIkChains: CcdIkPreparedChain[] = [];
+  private currentIkPropertyFrame: MmdAnimation["propertyFrames"][number] | undefined;
+  private currentIkPropertyFrameIndex = -1;
+  private readonly disabledIkBoneNames = new Set<string>();
   private readonly scratchAppendTranslations: THREE.Vector3[] = [];
   private readonly scratchAppendRotations: THREE.Quaternion[] = [];
   private readonly scratchReapplyAppendTranslations: THREE.Vector3[] = [];
@@ -51,6 +55,7 @@ export class DefaultMmdRuntime implements MmdRuntime {
     this.state = createFrameState(seconds, this.frameRate);
     if (this.mmdAnimation && this.mesh) {
       this.applyCurrentMmdAnimation(this.state.frame);
+      this.updateCurrentIkStates(this.state.frame);
       this.captureDebugStage("vmdInterpolation");
     }
     this.applyCurrentAppendTransforms();
@@ -109,6 +114,10 @@ export class DefaultMmdRuntime implements MmdRuntime {
   clearAnimation(): void {
     this.mmdAnimation = undefined;
     this.bonePhysicsToggles = {};
+    this.activeIkChains.length = 0;
+    this.currentIkPropertyFrame = undefined;
+    this.currentIkPropertyFrameIndex = -1;
+    this.disabledIkBoneNames.clear();
   }
 
   /**
@@ -127,6 +136,10 @@ export class DefaultMmdRuntime implements MmdRuntime {
     this.externalPhysicsData = undefined;
     this.bonePhysicsToggles = {};
     this.preparedIkChains = [];
+    this.activeIkChains.length = 0;
+    this.currentIkPropertyFrame = undefined;
+    this.currentIkPropertyFrameIndex = -1;
+    this.disabledIkBoneNames.clear();
     this.debugStages = createEmptyDebugStages();
     this.previousEvaluateSeconds = undefined;
     this.physicsDisabled = false;
@@ -146,7 +159,12 @@ export class DefaultMmdRuntime implements MmdRuntime {
       readIkChains(mesh),
       createCcdIkStaticBones(mesh)
     );
+    this.activeIkChains.length = 0;
+    this.currentIkPropertyFrame = undefined;
+    this.currentIkPropertyFrameIndex = -1;
+    this.disabledIkBoneNames.clear();
     this.applyCurrentMmdAnimation(this.state.frame);
+    this.updateCurrentIkStates(this.state.frame);
   }
 
   private prepareAnimationTarget(mesh: THREE.SkinnedMesh): void {
@@ -205,13 +223,14 @@ export class DefaultMmdRuntime implements MmdRuntime {
   }
 
   private solveIk(): Set<number> {
+    const chains = this.currentEnabledIkChains();
     if (!this.hasHandTwistIkChain()) {
-      const sourceBoneIndices = solvePreparedIk(this.mesh, this.ikSolver, this.preparedIkChains);
+      const sourceBoneIndices = solvePreparedIk(this.mesh, this.ikSolver, chains);
       this.reapplyCurrentAppendTransformsForSources(sourceBoneIndices);
       return sourceBoneIndices;
     }
     const changedBoneIndices = new Set<number>();
-    for (const chain of this.preparedIkChains) {
+    for (const chain of chains) {
       const chainSourceBoneIndices = solvePreparedIk(this.mesh, this.ikSolver, [chain]);
       for (const index of chainSourceBoneIndices) {
         changedBoneIndices.add(index);
@@ -219,6 +238,49 @@ export class DefaultMmdRuntime implements MmdRuntime {
       this.reapplyCurrentAppendTransformsForSources(chainSourceBoneIndices);
     }
     return changedBoneIndices;
+  }
+
+  private currentEnabledIkChains(): readonly CcdIkPreparedChain[] {
+    if (this.disabledIkBoneNames.size === 0) {
+      return this.preparedIkChains;
+    }
+    return this.activeIkChains;
+  }
+
+  private rebuildActiveIkChains(): void {
+    this.activeIkChains.length = 0;
+    const bones = this.mesh?.skeleton.bones;
+    if (!bones) {
+      return;
+    }
+    for (const chain of this.preparedIkChains) {
+      if (this.isIkChainEnabled(chain, bones)) {
+        this.activeIkChains.push(chain);
+      }
+    }
+  }
+
+  private isIkChainEnabled(
+    chain: CcdIkPreparedChain,
+    bones: readonly THREE.Bone[]
+  ): boolean {
+    const bone = bones[chain.goalBoneIndex];
+    if (!bone) {
+      return true;
+    }
+    if (this.disabledIkBoneNames.has(bone.name)) {
+      return false;
+    }
+    const mmdName = bone.userData.mmdBoneName;
+    if (typeof mmdName === "string" && this.disabledIkBoneNames.has(mmdName)) {
+      return false;
+    }
+    const ikStateName = bone.userData.mmdIkStateName;
+    if (typeof ikStateName === "string" && this.disabledIkBoneNames.has(ikStateName)) {
+      return false;
+    }
+    const englishName = bone.userData.mmdEnglishBoneName;
+    return !(typeof englishName === "string" && this.disabledIkBoneNames.has(englishName));
   }
 
   private hasHandTwistIkChain(): boolean {
@@ -245,6 +307,46 @@ export class DefaultMmdRuntime implements MmdRuntime {
     if (!result) return;
     this.bonePhysicsToggles = result.bonePhysicsToggles;
     this.preAppendTransforms = result.preAppendTransforms;
+  }
+
+  private updateCurrentIkStates(frame: number): void {
+    const propertyFrame = this.sampleCurrentPropertyFrame(frame);
+    if (propertyFrame === this.currentIkPropertyFrame) {
+      return;
+    }
+    this.currentIkPropertyFrame = propertyFrame;
+    this.disabledIkBoneNames.clear();
+    this.activeIkChains.length = 0;
+    if (!propertyFrame) {
+      return;
+    }
+    for (const state of propertyFrame.ikStates) {
+      if (!state.enabled) {
+        this.disabledIkBoneNames.add(state.boneName);
+      }
+    }
+    if (this.disabledIkBoneNames.size > 0) {
+      this.rebuildActiveIkChains();
+    }
+  }
+
+  private sampleCurrentPropertyFrame(frame: number): MmdAnimation["propertyFrames"][number] | undefined {
+    const frames = this.mmdAnimation?.propertyFrames;
+    if (!frames || frames.length === 0 || frame < frames[0]!.frame) {
+      this.currentIkPropertyFrameIndex = -1;
+      return undefined;
+    }
+    let index = this.currentIkPropertyFrameIndex;
+    const current = index >= 0 && index < frames.length ? frames[index] : undefined;
+    if (!current || current.frame > frame) {
+      index = findPropertyFrameIndex(frames, frame);
+    } else {
+      while (index + 1 < frames.length && (frames[index + 1]?.frame ?? Number.POSITIVE_INFINITY) <= frame) {
+        index += 1;
+      }
+    }
+    this.currentIkPropertyFrameIndex = index;
+    return frames[index];
   }
 
 
@@ -379,6 +481,24 @@ export class DefaultMmdRuntime implements MmdRuntime {
   }
 }
 
+
+function findPropertyFrameIndex(
+  frames: readonly MmdAnimation["propertyFrames"][number][],
+  frame: number
+): number {
+  let low = 0;
+  let high = frames.length - 1;
+  while (low <= high) {
+    const middle = (low + high) >> 1;
+    const middleFrame = frames[middle]?.frame ?? Number.POSITIVE_INFINITY;
+    if (middleFrame <= frame) {
+      low = middle + 1;
+    } else {
+      high = middle - 1;
+    }
+  }
+  return Math.max(0, high);
+}
 
 function syncRuntimeMeshForRender(mesh: THREE.Object3D | undefined): void {
   if (!mesh) {

--- a/src/runtime/index.ts
+++ b/src/runtime/index.ts
@@ -1,4 +1,4 @@
 export { DefaultMmdRuntime } from "./core.js";
-export { sampleMmdCameraTrack, sampleMmdLightTrack } from "./animation.js";
+export { sampleMmdCameraTrack, sampleMmdCameraTrackInto, sampleMmdLightTrack } from "./animation.js";
 export type { DefaultMmdRuntimeOptions, MmdFrameState, MmdRuntime, MmdRuntimeDebugStageState, MmdRuntimeDebugState, MmdRuntimeEvaluateOptions, MmdRuntimeTickOptions } from "./types.js";
 export * from "./ik/index.js";

--- a/src/three/camera.ts
+++ b/src/three/camera.ts
@@ -8,6 +8,9 @@ export interface ApplyMmdCameraStateOptions {
   readonly euler?: THREE.Euler;
   readonly quaternion?: THREE.Quaternion;
   readonly up?: THREE.Vector3;
+  readonly outsideParent?: THREE.Object3D;
+  readonly outsideParentWorldPosition?: THREE.Vector3;
+  readonly outsideParentScratch?: THREE.Vector3;
   readonly minFov?: number;
   readonly minOrthographicHeight?: number;
   readonly aspect?: number;
@@ -19,6 +22,8 @@ const defaultOffsetScratch = new THREE.Vector3();
 const defaultEulerScratch = new THREE.Euler();
 const defaultQuaternionScratch = new THREE.Quaternion();
 const defaultUpScratch = new THREE.Vector3();
+const defaultOutsideParentScratch = new THREE.Vector3();
+const positiveDistanceCameraFlip = new THREE.Quaternion(0, 1, 0, 0);
 
 export function applyMmdCameraStateToThreeCamera(
   camera: THREE.PerspectiveCamera,
@@ -32,13 +37,22 @@ export function applyMmdCameraStateToThreeCamera(
   const euler = options?.euler ?? defaultEulerScratch;
   const quaternion = options?.quaternion ?? defaultQuaternionScratch;
   const up = options?.up ?? defaultUpScratch;
+  const outsideParent = options?.outsideParent;
   target.set(state.position[0], state.position[1], -state.position[2]);
+  if (outsideParent) {
+    target.add(outsideParent.getWorldPosition(options?.outsideParentScratch ?? defaultOutsideParentScratch));
+  } else if (options?.outsideParentWorldPosition) {
+    target.add(options.outsideParentWorldPosition);
+  }
   euler.set(-state.rotation[0], -state.rotation[1], state.rotation[2], "YXZ");
   quaternion.setFromEuler(euler).invert();
   offset.set(0, 0, -state.distance).applyQuaternion(quaternion);
+  if (state.distance > 0) {
+    quaternion.multiply(positiveDistanceCameraFlip);
+  }
   activeCamera.position.copy(target).add(offset);
+  activeCamera.quaternion.copy(quaternion);
   activeCamera.up.copy(up.set(0, 1, 0).applyQuaternion(quaternion));
-  activeCamera.lookAt(target);
   activeCamera.userData.mmdCameraPerspective = state.perspective;
   if (activeCamera instanceof THREE.PerspectiveCamera) {
     activeCamera.fov = Math.max(state.fov, options?.minFov ?? 1);

--- a/src/three/camera.ts
+++ b/src/three/camera.ts
@@ -1,0 +1,62 @@
+import * as THREE from "three";
+
+import type { CameraState } from "../parser/model/modelTypes.js";
+
+export interface ApplyMmdCameraStateOptions {
+  readonly target?: THREE.Vector3;
+  readonly offset?: THREE.Vector3;
+  readonly euler?: THREE.Euler;
+  readonly quaternion?: THREE.Quaternion;
+  readonly up?: THREE.Vector3;
+  readonly minFov?: number;
+  readonly minOrthographicHeight?: number;
+  readonly aspect?: number;
+  readonly orthographicCamera?: THREE.OrthographicCamera;
+}
+
+const defaultTargetScratch = new THREE.Vector3();
+const defaultOffsetScratch = new THREE.Vector3();
+const defaultEulerScratch = new THREE.Euler();
+const defaultQuaternionScratch = new THREE.Quaternion();
+const defaultUpScratch = new THREE.Vector3();
+
+export function applyMmdCameraStateToThreeCamera(
+  camera: THREE.PerspectiveCamera,
+  state: CameraState,
+  options?: ApplyMmdCameraStateOptions
+): THREE.PerspectiveCamera | THREE.OrthographicCamera {
+  const activeCamera =
+    state.perspective || !options?.orthographicCamera ? camera : options.orthographicCamera;
+  const target = options?.target ?? defaultTargetScratch;
+  const offset = options?.offset ?? defaultOffsetScratch;
+  const euler = options?.euler ?? defaultEulerScratch;
+  const quaternion = options?.quaternion ?? defaultQuaternionScratch;
+  const up = options?.up ?? defaultUpScratch;
+  target.set(state.position[0], state.position[1], -state.position[2]);
+  euler.set(-state.rotation[0], -state.rotation[1], state.rotation[2], "YXZ");
+  quaternion.setFromEuler(euler).invert();
+  offset.set(0, 0, -state.distance).applyQuaternion(quaternion);
+  activeCamera.position.copy(target).add(offset);
+  activeCamera.up.copy(up.set(0, 1, 0).applyQuaternion(quaternion));
+  activeCamera.lookAt(target);
+  activeCamera.userData.mmdCameraPerspective = state.perspective;
+  if (activeCamera instanceof THREE.PerspectiveCamera) {
+    activeCamera.fov = Math.max(state.fov, options?.minFov ?? 1);
+  } else if (activeCamera instanceof THREE.OrthographicCamera) {
+    const fov = Math.max(state.fov, options?.minFov ?? 1);
+    const height = Math.max(
+      2 * Math.abs(state.distance) * Math.tan(THREE.MathUtils.degToRad(fov) / 2),
+      options?.minOrthographicHeight ?? 1e-3
+    );
+    const halfHeight = height / 2;
+    const halfWidth = halfHeight * (options?.aspect ?? 1);
+    activeCamera.left = -halfWidth;
+    activeCamera.right = halfWidth;
+    activeCamera.top = halfHeight;
+    activeCamera.bottom = -halfHeight;
+    activeCamera.near = camera.near;
+    activeCamera.far = camera.far;
+  }
+  activeCamera.updateProjectionMatrix();
+  return activeCamera;
+}

--- a/src/three/dispose.ts
+++ b/src/three/dispose.ts
@@ -6,14 +6,20 @@ export function disposeMmdModel(model: ThreeMmdModel): void {
   const disposedGeometries = new Set<THREE.BufferGeometry>();
   const disposedMaterials = new Set<THREE.Material>();
   const disposedTextures = new Set<THREE.Texture>();
+  const disposedSkeletons = new Set<THREE.Skeleton>();
+  const bodyMeshes = Array.isArray(model.mesh.userData.mmdMorphSplitBodyMeshes)
+    ? model.mesh.userData.mmdMorphSplitBodyMeshes.filter(isSkinnedMesh)
+    : [];
   const meshes = [
     model.mesh,
+    ...bodyMeshes,
     ...(model.outlineMeshes ?? []),
     ...(model.renderOrderMeshes ?? [])
   ];
+  model.object?.parent?.remove(model.object);
   for (const mesh of meshes) {
     mesh.parent?.remove(mesh);
-    disposeSkeletonResources(mesh.skeleton);
+    disposeSkeletonResources(mesh.skeleton, disposedSkeletons);
     if (mesh.geometry && !disposedGeometries.has(mesh.geometry)) {
       mesh.geometry.dispose();
       disposedGeometries.add(mesh.geometry);
@@ -22,6 +28,15 @@ export function disposeMmdModel(model: ThreeMmdModel): void {
       disposeMaterialResources(material, disposedMaterials, disposedTextures);
     }
   }
+}
+
+function isSkinnedMesh(value: unknown): value is THREE.SkinnedMesh {
+  return (
+    value instanceof THREE.SkinnedMesh ||
+    (typeof value === "object" &&
+      value !== null &&
+      (value as { readonly isSkinnedMesh?: unknown }).isSkinnedMesh === true)
+  );
 }
 
 function disposeMaterialResources(
@@ -75,11 +90,15 @@ function disposeTexture(
   disposedTextures.add(texture);
 }
 
-function disposeSkeletonResources(skeleton: THREE.Skeleton | undefined): void {
-  if (!skeleton) {
+function disposeSkeletonResources(
+  skeleton: THREE.Skeleton | undefined,
+  disposedSkeletons: Set<THREE.Skeleton>
+): void {
+  if (!skeleton || disposedSkeletons.has(skeleton)) {
     return;
   }
   skeleton.dispose();
+  disposedSkeletons.add(skeleton);
 }
 
 function normalizeMaterials(material: THREE.Material | THREE.Material[]): THREE.Material[] {

--- a/src/three/geometry.ts
+++ b/src/three/geometry.ts
@@ -66,6 +66,15 @@ export interface ThreeMmdGeometryMorph {
   readonly denseAdditionalUvOffsets?: readonly (Float32Array | undefined)[];
 }
 
+export interface ThreeMmdMorphSplitGeometry {
+  readonly geometry: THREE.BufferGeometry;
+  readonly materialIndex: number;
+  readonly morphTargetIndices: Uint16Array | Uint32Array;
+  readonly sourceVertexCount: number;
+  readonly vertexCount: number;
+  readonly morphPositionAttributeCount: number;
+}
+
 type DenseProviderMorph = ThreeMmdGeometryMorph & {
   readonly [denseMorphProviderSymbol]?: DenseMorphProvider;
 };
@@ -148,12 +157,14 @@ export function createThreeBufferGeometry(
   if (morphs.length > 0) {
     const morphAttributes = geometry.morphAttributes as Record<string, THREE.BufferAttribute[]>;
     geometry.morphTargetsRelative = true;
-    geometry.morphAttributes.position = createMorphAttributes(
-      morphs,
-      buffers.positions.length,
-      3,
-      (morph, length) => createThreeMorphPositionOffsets(length, morph)
-    );
+    if (morphs.some(hasPositionMorphOffsets)) {
+      geometry.morphAttributes.position = createMorphAttributes(
+        morphs,
+        buffers.positions.length,
+        3,
+        (morph, length) => createThreeMorphPositionOffsets(length, morph)
+      );
+    }
     if (morphs.some(hasUvMorphOffsets)) {
       morphAttributes.uv = createMorphAttributes(
         morphs,
@@ -180,6 +191,46 @@ export function createThreeBufferGeometry(
 
   geometry.computeBoundingSphere();
   return geometry;
+}
+
+export function createThreeMorphSplitGeometries(
+  buffers: ThreeMmdGeometryBuffers,
+  materials: readonly ThreeMmdGeometryMaterial[] = [],
+  morphs: readonly ThreeMmdGeometryMorph[] = []
+): ThreeMmdMorphSplitGeometry[] {
+  validateGeometryInput(buffers, materials, morphs);
+  const groups = createMmdRenderOrderGroups(buffers, materials);
+  if (groups.length <= 1 || !morphs.some(hasGeometryMorphOffsets)) {
+    return [];
+  }
+
+  const result: ThreeMmdMorphSplitGeometry[] = [];
+  for (const group of groups) {
+    const split = createMaterialSplitBuffers(buffers, group);
+    const splitMorphs = createMaterialSplitMorphs(morphs, split.sourceToLocal, split.localToSource);
+    const geometry = createThreeBufferGeometry(
+      split.buffers,
+      [{ faceCount: group.count / 3, materialIndex: group.materialIndex }],
+      splitMorphs.morphs
+    );
+    geometry.clearGroups();
+    geometry.addGroup(0, split.buffers.indices.length, group.materialIndex);
+    geometry.userData.mmdMorphSplit = {
+      materialIndex: group.materialIndex,
+      sourceVertexCount: buffers.positions.length / 3,
+      vertexCount: split.localToSource.length,
+      sourceGroup: { ...group }
+    };
+    result.push({
+      geometry,
+      materialIndex: group.materialIndex,
+      morphTargetIndices: splitMorphs.morphTargetIndices,
+      sourceVertexCount: buffers.positions.length / 3,
+      vertexCount: split.localToSource.length,
+      morphPositionAttributeCount: geometry.morphAttributes.position?.length ?? 0
+    });
+  }
+  return result;
 }
 
 function createMmdRenderOrderGroups(
@@ -225,6 +276,229 @@ function createMaterialFaceCountGroups(
     groupStart += groupCount;
     return group;
   });
+}
+
+function createMaterialSplitBuffers(
+  buffers: ThreeMmdGeometryBuffers,
+  group: ThreeMmdMaterialGroup
+): {
+  readonly buffers: ThreeMmdGeometryBuffers;
+  readonly sourceToLocal: Int32Array;
+  readonly localToSource: Uint32Array;
+} {
+  const sourceVertexCount = buffers.positions.length / 3;
+  const sourceToLocal = new Int32Array(sourceVertexCount);
+  sourceToLocal.fill(-1);
+  const localVertices: number[] = [];
+  for (let indexOffset = group.start; indexOffset < group.start + group.count; indexOffset += 1) {
+    const sourceIndex = buffers.indices[indexOffset] ?? 0;
+    if (sourceToLocal[sourceIndex] >= 0) {
+      continue;
+    }
+    sourceToLocal[sourceIndex] = localVertices.length;
+    localVertices.push(sourceIndex);
+  }
+
+  const localToSource = new Uint32Array(localVertices);
+  const indexArray =
+    localVertices.length > 65535
+      ? new Uint32Array(group.count)
+      : new Uint16Array(group.count);
+  for (let indexOffset = 0; indexOffset < group.count; indexOffset += 1) {
+    const sourceIndex = buffers.indices[group.start + indexOffset] ?? 0;
+    indexArray[indexOffset] = sourceToLocal[sourceIndex];
+  }
+
+  const vertexCount = localVertices.length;
+  const splitBuffers = {
+    positions: copySplitFloatAttribute(buffers.positions, 3, localToSource),
+    normals: copySplitFloatAttribute(buffers.normals, 3, localToSource),
+    uvs: copySplitFloatAttribute(buffers.uvs, 2, localToSource),
+    additionalUvs: buffers.additionalUvs?.map((additionalUv) =>
+      copySplitFloatAttribute(additionalUv, 4, localToSource)
+    ),
+    indices: indexArray,
+    skinIndices: copySplitUint16Attribute(buffers.skinIndices, 4, localToSource),
+    skinWeights: copySplitFloatAttribute(buffers.skinWeights, 4, localToSource),
+    edgeScale: buffers.edgeScale
+      ? copySplitFloatAttribute(buffers.edgeScale, 1, localToSource)
+      : undefined,
+    sdef: buffers.sdef
+      ? {
+          enabled: copySplitFloatAttribute(buffers.sdef.enabled, 1, localToSource),
+          c: copySplitFloatAttribute(buffers.sdef.c, 3, localToSource),
+          r0: copySplitFloatAttribute(buffers.sdef.r0, 3, localToSource),
+          r1: copySplitFloatAttribute(buffers.sdef.r1, 3, localToSource),
+          rw0: copySplitFloatAttribute(buffers.sdef.rw0, 3, localToSource),
+          rw1: copySplitFloatAttribute(buffers.sdef.rw1, 3, localToSource)
+        }
+      : undefined,
+    materialGroups: [{ start: 0, count: group.count, materialIndex: group.materialIndex }]
+  } satisfies ThreeMmdGeometryBuffers;
+  if (vertexCount === 0) {
+    throw new RangeError(`THREE_MMD_GEOMETRY_MATERIAL_GROUP_EMPTY:${group.materialIndex}`);
+  }
+  return { buffers: splitBuffers, sourceToLocal, localToSource };
+}
+
+function copySplitFloatAttribute(
+  source: Float32Array,
+  itemSize: number,
+  localToSource: Uint32Array
+): Float32Array {
+  const target = new Float32Array(localToSource.length * itemSize);
+  for (let localIndex = 0; localIndex < localToSource.length; localIndex += 1) {
+    const sourceIndex = localToSource[localIndex] ?? 0;
+    const sourceBase = sourceIndex * itemSize;
+    const targetBase = localIndex * itemSize;
+    for (let component = 0; component < itemSize; component += 1) {
+      target[targetBase + component] = source[sourceBase + component] ?? 0;
+    }
+  }
+  return target;
+}
+
+function copySplitUint16Attribute(
+  source: Uint16Array,
+  itemSize: number,
+  localToSource: Uint32Array
+): Uint16Array {
+  const target = new Uint16Array(localToSource.length * itemSize);
+  for (let localIndex = 0; localIndex < localToSource.length; localIndex += 1) {
+    const sourceIndex = localToSource[localIndex] ?? 0;
+    const sourceBase = sourceIndex * itemSize;
+    const targetBase = localIndex * itemSize;
+    for (let component = 0; component < itemSize; component += 1) {
+      target[targetBase + component] = source[sourceBase + component] ?? 0;
+    }
+  }
+  return target;
+}
+
+function createMaterialSplitMorphs(
+  morphs: readonly ThreeMmdGeometryMorph[],
+  sourceToLocal: Int32Array,
+  localToSource: Uint32Array
+): {
+  readonly morphs: ThreeMmdGeometryMorph[];
+  readonly morphTargetIndices: Uint16Array | Uint32Array;
+} {
+  const splitMorphs: ThreeMmdGeometryMorph[] = [];
+  const morphTargetIndices =
+    morphs.length > 65535 ? new Uint32Array(morphs.length) : new Uint16Array(morphs.length);
+  let splitIndex = 0;
+  for (let morphIndex = 0; morphIndex < morphs.length; morphIndex += 1) {
+    const morph = morphs[morphIndex];
+    if (!morph) {
+      continue;
+    }
+    const splitMorph: ThreeMmdGeometryMorph = {
+      vertexOffsets: splitVertexOffsets(morph, sourceToLocal, localToSource),
+      uvOffsets: splitUvOffsets(morph, sourceToLocal, localToSource),
+      additionalUvOffsets: splitAdditionalUvOffsets(morph, sourceToLocal, localToSource)
+    };
+    if (!hasGeometryMorphOffsets(splitMorph)) {
+      continue;
+    }
+    splitMorphs.push(splitMorph);
+    morphTargetIndices[splitIndex] = morphIndex;
+    splitIndex += 1;
+  }
+  return {
+    morphs: splitMorphs,
+    morphTargetIndices: morphTargetIndices.slice(0, splitIndex)
+  };
+}
+
+function splitVertexOffsets(
+  morph: ThreeMmdGeometryMorph,
+  sourceToLocal: Int32Array,
+  localToSource: Uint32Array
+): ThreeMmdVertexMorphOffset[] | undefined {
+  if (morph.densePositionOffsets) {
+    const offsets: ThreeMmdVertexMorphOffset[] = [];
+    for (let localIndex = 0; localIndex < localToSource.length; localIndex += 1) {
+      const sourceBase = (localToSource[localIndex] ?? 0) * 3;
+      const x = morph.densePositionOffsets[sourceBase] ?? 0;
+      const y = morph.densePositionOffsets[sourceBase + 1] ?? 0;
+      const z = morph.densePositionOffsets[sourceBase + 2] ?? 0;
+      if (x !== 0 || y !== 0 || z !== 0) {
+        offsets.push({ vertexIndex: localIndex, position: [x, y, z] });
+      }
+    }
+    return offsets.length > 0 ? offsets : undefined;
+  }
+  if (!morph.vertexOffsets?.length) {
+    return undefined;
+  }
+  const offsets: ThreeMmdVertexMorphOffset[] = [];
+  for (const offset of morph.vertexOffsets) {
+    const localIndex = sourceToLocal[offset.vertexIndex] ?? -1;
+    if (localIndex >= 0) {
+      offsets.push({ vertexIndex: localIndex, position: offset.position });
+    }
+  }
+  return offsets.length > 0 ? offsets : undefined;
+}
+
+function splitUvOffsets(
+  morph: ThreeMmdGeometryMorph,
+  sourceToLocal: Int32Array,
+  localToSource: Uint32Array
+): ThreeMmdUvMorphOffset[] | undefined {
+  if (morph.denseUvOffsets) {
+    const offsets: ThreeMmdUvMorphOffset[] = [];
+    for (let localIndex = 0; localIndex < localToSource.length; localIndex += 1) {
+      const sourceBase = (localToSource[localIndex] ?? 0) * 2;
+      const u = morph.denseUvOffsets[sourceBase] ?? 0;
+      const v = morph.denseUvOffsets[sourceBase + 1] ?? 0;
+      if (u !== 0 || v !== 0) {
+        offsets.push({ vertexIndex: localIndex, uv: [u, v, 0, 0] });
+      }
+    }
+    return offsets.length > 0 ? offsets : undefined;
+  }
+  if (!morph.uvOffsets?.length) {
+    return undefined;
+  }
+  const offsets: ThreeMmdUvMorphOffset[] = [];
+  for (const offset of morph.uvOffsets) {
+    const localIndex = sourceToLocal[offset.vertexIndex] ?? -1;
+    if (localIndex >= 0) {
+      offsets.push({ vertexIndex: localIndex, uv: offset.uv });
+    }
+  }
+  return offsets.length > 0 ? offsets : undefined;
+}
+
+function splitAdditionalUvOffsets(
+  morph: ThreeMmdGeometryMorph,
+  sourceToLocal: Int32Array,
+  localToSource: Uint32Array
+): ThreeMmdAdditionalUvMorphOffset[] | undefined {
+  const offsets: ThreeMmdAdditionalUvMorphOffset[] = [];
+  morph.denseAdditionalUvOffsets?.forEach((denseOffsets, uvIndex) => {
+    if (!denseOffsets) {
+      return;
+    }
+    for (let localIndex = 0; localIndex < localToSource.length; localIndex += 1) {
+      const sourceBase = (localToSource[localIndex] ?? 0) * 4;
+      const x = denseOffsets[sourceBase] ?? 0;
+      const y = denseOffsets[sourceBase + 1] ?? 0;
+      const z = denseOffsets[sourceBase + 2] ?? 0;
+      const w = denseOffsets[sourceBase + 3] ?? 0;
+      if (x !== 0 || y !== 0 || z !== 0 || w !== 0) {
+        offsets.push({ vertexIndex: localIndex, uvIndex, uv: [x, y, z, w] });
+      }
+    }
+  });
+  for (const offset of morph.additionalUvOffsets ?? []) {
+    const localIndex = sourceToLocal[offset.vertexIndex] ?? -1;
+    if (localIndex >= 0) {
+      offsets.push({ vertexIndex: localIndex, uvIndex: offset.uvIndex, uv: offset.uv });
+    }
+  }
+  return offsets.length > 0 ? offsets : undefined;
 }
 
 function validateGeometryInput(
@@ -503,10 +777,28 @@ function hasUvMorphOffsets(morph: ThreeMmdGeometryMorph): boolean {
   return !!morph.uvOffsets?.length || !!morph.denseUvOffsets;
 }
 
+function hasPositionMorphOffsets(morph: ThreeMmdGeometryMorph): boolean {
+  return (
+    !!morph.vertexOffsets?.length ||
+    !!morph.densePositionOffsets
+  );
+}
+
 function hasAdditionalUvMorphOffsets(morph: ThreeMmdGeometryMorph, uvIndex: number): boolean {
   return (
     !!morph.denseAdditionalUvOffsets?.[uvIndex] ||
     !!morph.additionalUvOffsets?.some((offset) => offset.uvIndex === uvIndex)
+  );
+}
+
+function hasGeometryMorphOffsets(morph: ThreeMmdGeometryMorph): boolean {
+  return (
+    !!morph.vertexOffsets?.length ||
+    !!morph.densePositionOffsets ||
+    !!morph.uvOffsets?.length ||
+    !!morph.denseUvOffsets ||
+    !!morph.additionalUvOffsets?.length ||
+    !!morph.denseAdditionalUvOffsets?.some((offsets) => !!offsets)
   );
 }
 

--- a/src/three/index.ts
+++ b/src/three/index.ts
@@ -5,14 +5,16 @@ import { parseVpd } from "../parser/index.js";
 import type { MmdAnimation, MmdCore, MmdPose, VmdBoneTrack } from "../parser/model/modelTypes.js";
 import { DefaultMmdRuntime } from "../runtime/index.js";
 import type { MmdRuntime, DefaultMmdRuntimeOptions } from "../runtime/index.js";
-import { createThreeBufferGeometry } from "./geometry.js";
+import { createThreeBufferGeometry, createThreeMorphSplitGeometries } from "./geometry.js";
 import { createLoaderMmdModelDataFromModel } from "./modelAssembly.js";
 import type { LoaderMmdModelData } from "./internalModelData.js";
 import { applyThreeMmdMaterialTextures, createThreeMmdMaterials } from "./materials.js";
 import {
   computeMmdMaterialRenderOrder,
+  mmdMaterialCastsShadow,
   syncMmdModelShadowFlags
 } from "./material/material-metadata.js";
+import type { MmdMaterialRenderOrderEntry } from "./material/material-metadata.js";
 import { attachMmdSdefSkinning } from "./material/material-sdef.js";
 import type { TextureLoadDiagnostic, ThreeMmdTextureLoader } from "./materials.js";
 import { isModelSource } from "./modelSource.js";
@@ -25,7 +27,7 @@ import { createLoaderPerformanceProfile } from "./performance.js";
 import { createThreeSkeleton } from "./skeleton.js";
 import type { ModelSource } from "./modelSource.js";
 import type { TextureMap, TextureResolver } from "./textures.js";
-export { createThreeBufferGeometry } from "./geometry.js";
+export { createThreeBufferGeometry, createThreeMorphSplitGeometries } from "./geometry.js";
 export { applyMmdCameraStateToThreeCamera } from "./camera.js";
 export { disposeMmdModel } from "./dispose.js";
 export {
@@ -91,6 +93,7 @@ export type {
   ThreeMmdGeometryBuffers,
   ThreeMmdGeometryMaterial,
   ThreeMmdGeometryMorph,
+  ThreeMmdMorphSplitGeometry,
   ThreeMmdMaterialGroup,
   ThreeMmdSdefBuffers,
   ThreeMmdUvMorphOffset,
@@ -233,6 +236,7 @@ export class ThreeMmdLoader {
         if (options.frustumCulled !== undefined) {
           mesh.frustumCulled = options.frustumCulled;
         }
+        syncMorphSplitBodyMeshRenderState(mesh, modelData.materials);
         profile?.mark("materials");
         const model = createThreeMmdModel({
           mesh,
@@ -346,11 +350,15 @@ function createThreeMmdModel(options: {
   readonly outlines: boolean;
   readonly renderOrderProxies: boolean;
 }): ThreeMmdModel {
+  const bodyMeshes = readMorphSplitBodyMeshes(options.mesh);
+  const outlineSources = bodyMeshes.length > 0 ? bodyMeshes : [options.mesh];
   const outlineMeshes = options.outlines
-    ? createMmdOutlineMeshes({
-        mesh: options.mesh,
-        materials: options.materials
-      })
+    ? outlineSources.flatMap((mesh) =>
+        createMmdOutlineMeshes({
+          mesh,
+          materials: options.materials
+        })
+      )
     : [];
   outlineMeshes.forEach((outline) => {
     syncMmdModelShadowFlags(outline, options.materials);
@@ -358,18 +366,18 @@ function createThreeMmdModel(options: {
   });
   // MMD-compatible outlines need body proxies so body/outline draw in PMX
   // material definition order: body0, outline0, body1, outline1.
-  const renderOrderMeshes = options.outlines && options.renderOrderProxies
+  const renderOrderMeshes = bodyMeshes.length === 0 && options.outlines && options.renderOrderProxies
     ? createMmdMaterialRenderOrderMeshes({
         mesh: options.mesh,
         materials: options.materials
       })
     : [];
-  if (renderOrderMeshes.length > 0) {
+  if (renderOrderMeshes.length > 0 || bodyMeshes.length > 0) {
     options.mesh.geometry.setDrawRange(0, 0);
   }
   const object = new THREE.Group();
   object.name = options.mesh.name;
-  object.add(options.mesh, ...renderOrderMeshes, ...outlineMeshes);
+  object.add(options.mesh, ...bodyMeshes, ...renderOrderMeshes, ...outlineMeshes);
   return {
     object,
     mesh: options.mesh,
@@ -379,6 +387,56 @@ function createThreeMmdModel(options: {
     source: options.source,
     textureDiagnostics: options.textureDiagnostics
   };
+}
+
+function readMorphSplitBodyMeshes(mesh: THREE.SkinnedMesh): THREE.SkinnedMesh[] {
+  const bodyMeshes = mesh.userData.mmdMorphSplitBodyMeshes;
+  return Array.isArray(bodyMeshes)
+    ? bodyMeshes.filter((candidate): candidate is THREE.SkinnedMesh => isSkinnedMesh(candidate))
+    : [];
+}
+
+function isSkinnedMesh(value: unknown): value is THREE.SkinnedMesh {
+  return (
+    value instanceof THREE.SkinnedMesh ||
+    (typeof value === "object" &&
+      value !== null &&
+      (value as { readonly isSkinnedMesh?: unknown }).isSkinnedMesh === true)
+  );
+}
+
+function syncMorphSplitBodyMeshRenderState(
+  mesh: THREE.SkinnedMesh,
+  materials: readonly LoaderMmdModelData["materials"][number][]
+): void {
+  const bodyMeshes = readMorphSplitBodyMeshes(mesh);
+  if (bodyMeshes.length === 0) {
+    return;
+  }
+  const renderOrder = mesh.userData.mmdMaterialRenderOrder as
+    | readonly MmdMaterialRenderOrderEntry[]
+    | undefined;
+  const renderOrderByMaterial = new Map(
+    (renderOrder ?? []).map((entry) => [entry.materialIndex, entry.renderOrder])
+  );
+  for (const body of bodyMeshes) {
+    const materialIndex = (body.userData.mmdMorphSplitBody as
+      | { readonly materialIndex?: unknown }
+      | undefined)?.materialIndex;
+    if (typeof materialIndex !== "number") {
+      continue;
+    }
+    body.renderOrder = (renderOrderByMaterial.get(materialIndex) ?? materialIndex) * 2;
+    body.userData.mmdMaterialRenderOrder = [{
+      materialIndex,
+      bucket: renderOrder?.find((entry) => entry.materialIndex === materialIndex)?.bucket ?? "opaque",
+      renderOrder: 0
+    }];
+    body.frustumCulled = mesh.frustumCulled;
+    const material = materials[materialIndex];
+    body.castShadow = !!material && mmdMaterialCastsShadow(material.flags);
+    body.receiveShadow = !!material?.flags.selfShadow;
+  }
 }
 
 function createModelSourceDescriptor(
@@ -426,18 +484,42 @@ function createEmptySourceError(method: string): Error {
 }
 
 function createThreeMmdMesh(modelData: LoaderMmdModelData): THREE.SkinnedMesh {
+  const splitGeometries = shouldCreateMorphSplitMeshes(modelData)
+    ? createThreeMorphSplitGeometries(modelData.geometry, modelData.materials, modelData.morphs)
+    : [];
   const geometry = createThreeBufferGeometry(
     modelData.geometry,
     modelData.materials,
-    modelData.morphs
+    splitGeometries.length > 0 ? [] : modelData.morphs
   );
   const materials = createThreeMmdMaterials(modelData.materials);
   if (geometry.userData.mmdSdef) {
     materials.forEach((material) => attachMmdSdefSkinning(material));
   }
   const mesh = new THREE.SkinnedMesh(geometry, materials.length === 1 ? materials[0] : materials);
+  const bodyMeshes = splitGeometries.map((split) => {
+    const body = new THREE.SkinnedMesh(split.geometry, materials);
+    body.name = `${modelData.metadata.englishName || modelData.metadata.name || "mmd"} material ${split.materialIndex}`;
+    body.frustumCulled = mesh.frustumCulled;
+    body.morphTargetDictionary = createMorphTargetDictionaryForIndices(
+      modelData.morphs,
+      split.morphTargetIndices
+    );
+    body.morphTargetInfluences = new Array(split.morphTargetIndices.length).fill(0);
+    body.userData.mmdMorphSplitBody = {
+      materialIndex: split.materialIndex,
+      morphTargetIndices: split.morphTargetIndices,
+      sourceVertexCount: split.sourceVertexCount,
+      vertexCount: split.vertexCount,
+      morphPositionAttributeCount: split.morphPositionAttributeCount
+    };
+    return body;
+  });
   mesh.morphTargetDictionary = createMorphTargetDictionary(modelData.morphs);
   mesh.morphTargetInfluences = new Array(modelData.morphs.length).fill(0);
+  bodyMeshes.forEach((body) => {
+    attachMorphSplitInfluenceSync(mesh, body);
+  });
   mesh.name = modelData.metadata.englishName || modelData.metadata.name;
   mesh.userData.mmdModel = {
     format: modelData.metadata.format,
@@ -490,6 +572,17 @@ function createThreeMmdMesh(modelData: LoaderMmdModelData): THREE.SkinnedMesh {
     impulseOffsets: morph.impulseOffsets?.map((offset) => ({ ...offset }))
   }));
   mesh.userData.mmdIkChains = createRuntimeIkChains(modelData);
+  if (bodyMeshes.length > 0) {
+    mesh.userData.mmdMorphSplitBodyMeshes = bodyMeshes;
+    mesh.userData.mmdMorphSplit = {
+      sourceVertexCount: modelData.geometry.positions.length / 3,
+      bodyMeshCount: bodyMeshes.length,
+      splitVertexCount: bodyMeshes.reduce((sum, body) => {
+        const position = body.geometry.getAttribute("position");
+        return sum + (position?.count ?? 0);
+      }, 0)
+    };
+  }
 
   const skeleton = createThreeSkeleton(modelData.skeleton);
   skeleton.bones.forEach((bone, index) => {
@@ -518,7 +611,75 @@ function createThreeMmdMesh(modelData: LoaderMmdModelData): THREE.SkinnedMesh {
     }
   });
   mesh.bind(skeleton);
+  bodyMeshes.forEach((body) => {
+    body.bind(skeleton, mesh.bindMatrix);
+    attachMorphSplitInfluenceSync(mesh, body);
+  });
   return mesh;
+}
+
+function createMorphTargetDictionaryForIndices(
+  morphs: readonly LoaderMmdModelData["morphs"][number][],
+  morphTargetIndices: Uint16Array | Uint32Array
+): Record<string, number> {
+  const dictionary: Record<string, number> = {};
+  for (let localIndex = 0; localIndex < morphTargetIndices.length; localIndex += 1) {
+    const morph = morphs[morphTargetIndices[localIndex] ?? -1];
+    if (!morph) {
+      continue;
+    }
+    const primaryName = morph.name || morph.englishName;
+    const secondaryName = morph.englishName || morph.name;
+    if (primaryName) {
+      dictionary[primaryName] = localIndex;
+    }
+    if (secondaryName && dictionary[secondaryName] === undefined) {
+      dictionary[secondaryName] = localIndex;
+    }
+  }
+  return dictionary;
+}
+
+function attachMorphSplitInfluenceSync(
+  source: THREE.SkinnedMesh,
+  target: THREE.SkinnedMesh
+): void {
+  const split = target.userData.mmdMorphSplitBody as
+    | { readonly morphTargetIndices?: Uint16Array | Uint32Array }
+    | undefined;
+  const morphTargetIndices = split?.morphTargetIndices;
+  if (!morphTargetIndices || target.userData.mmdMorphSplitInfluenceSyncAttached) {
+    return;
+  }
+  const previousOnBeforeRender = target.onBeforeRender.bind(target);
+  target.onBeforeRender = (renderer, scene, camera, geometry, material, group) => {
+    previousOnBeforeRender(renderer, scene, camera, geometry, material, group);
+    const sourceInfluences = source.morphTargetInfluences;
+    const targetInfluences = target.morphTargetInfluences;
+    if (!sourceInfluences || !targetInfluences) {
+      return;
+    }
+    for (let index = 0; index < morphTargetIndices.length; index += 1) {
+      targetInfluences[index] = sourceInfluences[morphTargetIndices[index] ?? -1] ?? 0;
+    }
+  };
+  target.userData.mmdMorphSplitInfluenceSyncAttached = true;
+}
+
+function shouldCreateMorphSplitMeshes(modelData: LoaderMmdModelData): boolean {
+  const vertexCount = modelData.geometry.positions.length / 3;
+  const groups = modelData.geometry.materialGroups?.length ?? modelData.materials.length;
+  if (vertexCount <= 0 || groups <= 1) {
+    return false;
+  }
+  const morphTargetCount = modelData.morphs.filter(
+    (morph) => morph.type === "vertex" || morph.type === "uv" || morph.type === "additionalUv"
+  ).length;
+  if (morphTargetCount === 0) {
+    return false;
+  }
+  const estimatedDenseBytes = vertexCount * morphTargetCount * 3 * Float32Array.BYTES_PER_ELEMENT;
+  return estimatedDenseBytes >= 64 * 1024 * 1024;
 }
 
 function createRuntimeIkChains(modelData: LoaderMmdModelData): unknown[] {

--- a/src/three/index.ts
+++ b/src/three/index.ts
@@ -498,6 +498,9 @@ function createThreeMmdMesh(modelData: LoaderMmdModelData): THREE.SkinnedMesh {
       bone.userData.mmdBoneName = boneData.name;
       bone.userData.mmdEnglishBoneName = boneData.englishName;
       bone.userData.mmdRestPosition = [...boneData.position];
+      if (boneData.ikStateName !== undefined) {
+        bone.userData.mmdIkStateName = boneData.ikStateName;
+      }
     }
     if (boneData?.appendTransform) {
       bone.userData.mmdAppendTransform = boneData.appendTransform;

--- a/src/three/index.ts
+++ b/src/three/index.ts
@@ -26,6 +26,7 @@ import { createThreeSkeleton } from "./skeleton.js";
 import type { ModelSource } from "./modelSource.js";
 import type { TextureMap, TextureResolver } from "./textures.js";
 export { createThreeBufferGeometry } from "./geometry.js";
+export { applyMmdCameraStateToThreeCamera } from "./camera.js";
 export { disposeMmdModel } from "./dispose.js";
 export {
   createMmdTextureMapFromFiles,
@@ -82,6 +83,9 @@ export {
   resolveMappedTexture,
   resolveMmdToonTextureReference
 } from "./textures.js";
+export type {
+  ApplyMmdCameraStateOptions
+} from "./camera.js";
 export type {
   ThreeMmdAdditionalUvMorphOffset,
   ThreeMmdGeometryBuffers,

--- a/src/three/modelAssembly.ts
+++ b/src/three/modelAssembly.ts
@@ -71,6 +71,7 @@ function createThreeMmdSkeletonBone(bone: BoneData): ThreeMmdSkeletonBone {
   return {
     name: bone.name,
     englishName: bone.englishName,
+    ikStateName: bone.ikStateName,
     parentIndex: bone.parentIndex,
     position: [...bone.position],
     layer: bone.layer,

--- a/src/three/skeleton.ts
+++ b/src/three/skeleton.ts
@@ -3,6 +3,7 @@ import * as THREE from "three";
 export interface ThreeMmdSkeletonBone {
   readonly name: string;
   readonly englishName: string;
+  readonly ikStateName?: string;
   readonly parentIndex: number;
   readonly position: readonly [number, number, number];
   readonly ik?: {

--- a/test/fixtures/fixtures.schema.json
+++ b/test/fixtures/fixtures.schema.json
@@ -143,6 +143,18 @@
         "motion": {
           "$ref": "#/$defs/playbackSmokeMotionRef"
         },
+        "background": {
+          "$ref": "#/$defs/playbackSmokeBackgroundRef",
+          "description": "Optional background fixture to load with the viewer preset."
+        },
+        "camera": {
+          "$ref": "#/$defs/playbackSmokeCameraRef",
+          "description": "Optional camera VMD fixture to load with the viewer preset."
+        },
+        "audio": {
+          "$ref": "#/$defs/playbackSmokeAudioRef",
+          "description": "Optional audio fixture to load with the viewer preset."
+        },
         "oracle": {
           "$ref": "#/$defs/relativeFilePath",
           "description": "Path to a gitignored native nanoem oracle JSON, resolved from basePath."
@@ -207,6 +219,47 @@
       "additionalProperties": false,
       "required": ["key"],
       "properties": {
+        "key": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "playbackSmokeBackgroundRef": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["extension", "key"],
+      "properties": {
+        "extension": {
+          "type": "string",
+          "enum": ["backgroundPmx", "backgroundPmd"]
+        },
+        "key": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "playbackSmokeCameraRef": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["key"],
+      "properties": {
+        "key": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "playbackSmokeAudioRef": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["extension", "key"],
+      "properties": {
+        "extension": {
+          "type": "string",
+          "enum": ["wav", "mp3", "ogg"]
+        },
         "key": {
           "type": "string",
           "minLength": 1

--- a/test/helpers/localPlaybackFixtures.ts
+++ b/test/helpers/localPlaybackFixtures.ts
@@ -13,12 +13,14 @@ export interface LocalPlaybackCase {
   readonly name: string;
   readonly modelPath: string;
   readonly motionPath: string;
+  readonly cameraMotionPath?: string;
   readonly oraclePath: string;
   readonly stage: NativeNanoemOracleStageName;
   readonly frames: readonly number[];
   readonly watchBones: readonly string[];
   readonly matrixEpsilon: number;
   readonly morphEpsilon: number;
+  readonly cameraEpsilon: number;
 }
 
 export interface LocalPlaybackSkippedCase {
@@ -35,6 +37,7 @@ interface FixtureInventory {
         readonly pmx: Record<string, string>;
         readonly pmd: Record<string, string>;
         readonly vmd: Record<string, string>;
+        readonly cameraVmd?: Record<string, string>;
         readonly vpd: Record<string, string>;
       };
     };
@@ -53,6 +56,9 @@ interface PlaybackSmokeCaseConfig {
   readonly motion: {
     readonly key: string;
   };
+  readonly camera?: {
+    readonly key: string;
+  };
   readonly oracle: string;
   readonly oracleKind: "native-nanoem-runtime-dump";
   readonly stage?: NativeNanoemOracleStageName;
@@ -60,6 +66,7 @@ interface PlaybackSmokeCaseConfig {
   readonly watchBones: readonly string[];
   readonly matrixEpsilon?: number;
   readonly morphEpsilon?: number;
+  readonly cameraEpsilon?: number;
   readonly skipReason?: string;
 }
 
@@ -112,6 +119,7 @@ export async function loadLocalPlaybackFixtures(
     const missingPath = await firstMissingPath([
       resolvedCase.modelPath,
       resolvedCase.motionPath,
+      ...(resolvedCase.cameraMotionPath ? [resolvedCase.cameraMotionPath] : []),
       resolvedCase.oraclePath
     ]);
     if (missingPath) {
@@ -143,6 +151,10 @@ function resolvePlaybackCase(
 ): LocalPlaybackCase {
   const modelPath = inventory.paths.releaseSmoke.byExtension[rawCase.model.extension][rawCase.model.key];
   const motionPath = inventory.paths.releaseSmoke.byExtension.vmd[rawCase.motion.key];
+  const cameraMotionPath =
+    rawCase.camera === undefined
+      ? undefined
+      : inventory.paths.releaseSmoke.byExtension.cameraVmd?.[rawCase.camera.key];
   if (!modelPath) {
     throw new Error(
       `${rawCase.name}: model key not found: ${rawCase.model.extension}.${rawCase.model.key}`
@@ -151,17 +163,22 @@ function resolvePlaybackCase(
   if (!motionPath) {
     throw new Error(`${rawCase.name}: motion key not found: vmd.${rawCase.motion.key}`);
   }
+  if (rawCase.camera !== undefined && !cameraMotionPath) {
+    throw new Error(`${rawCase.name}: camera key not found: cameraVmd.${rawCase.camera.key}`);
+  }
 
   return {
     name: rawCase.name,
     modelPath: resolve(basePath, modelPath),
     motionPath: resolve(basePath, motionPath),
+    cameraMotionPath: cameraMotionPath === undefined ? undefined : resolve(basePath, cameraMotionPath),
     oraclePath: resolve(basePath, rawCase.oracle),
     stage: rawCase.stage ?? "physics",
     frames: rawCase.frames,
     watchBones: rawCase.watchBones,
     matrixEpsilon: rawCase.matrixEpsilon ?? 1e-4,
-    morphEpsilon: rawCase.morphEpsilon ?? 1e-4
+    morphEpsilon: rawCase.morphEpsilon ?? 1e-4,
+    cameraEpsilon: rawCase.cameraEpsilon ?? 1e-4
   };
 }
 
@@ -192,6 +209,10 @@ function parseFixtureInventory(raw: unknown, label: string): FixtureInventory {
           pmx: parseStringMap(byExtension.pmx, `${label}.paths.releaseSmoke.byExtension.pmx`),
           pmd: parseStringMap(byExtension.pmd, `${label}.paths.releaseSmoke.byExtension.pmd`),
           vmd: parseStringMap(byExtension.vmd, `${label}.paths.releaseSmoke.byExtension.vmd`),
+          cameraVmd:
+            byExtension.cameraVmd === undefined
+              ? undefined
+              : parseStringMap(byExtension.cameraVmd, `${label}.paths.releaseSmoke.byExtension.cameraVmd`),
           vpd: parseStringMap(byExtension.vpd, `${label}.paths.releaseSmoke.byExtension.vpd`)
         }
       },
@@ -216,6 +237,8 @@ function parsePlaybackCaseConfig(raw: unknown, label: string): PlaybackSmokeCase
   const config = readRecord(raw, label);
   const model = readRecord(config.model, `${label}.model`);
   const motion = readRecord(config.motion, `${label}.motion`);
+  const camera =
+    config.camera === undefined ? undefined : readRecord(config.camera, `${label}.camera`);
   const extension = readString(model.extension, `${label}.model.extension`);
   const stage = config.stage === undefined ? "physics" : readStage(config.stage, `${label}.stage`);
   if (extension !== "pmx" && extension !== "pmd") {
@@ -233,6 +256,12 @@ function parsePlaybackCaseConfig(raw: unknown, label: string): PlaybackSmokeCase
     motion: {
       key: readString(motion.key, `${label}.motion.key`)
     },
+    camera:
+      camera === undefined
+        ? undefined
+        : {
+            key: readString(camera.key, `${label}.camera.key`)
+          },
     oracle: readString(config.oracle, `${label}.oracle`),
     oracleKind: "native-nanoem-runtime-dump",
     stage,
@@ -246,6 +275,10 @@ function parsePlaybackCaseConfig(raw: unknown, label: string): PlaybackSmokeCase
       config.morphEpsilon === undefined
         ? undefined
         : readPositiveNumber(config.morphEpsilon, `${label}.morphEpsilon`),
+    cameraEpsilon:
+      config.cameraEpsilon === undefined
+        ? undefined
+        : readPositiveNumber(config.cameraEpsilon, `${label}.cameraEpsilon`),
     skipReason:
       config.skipReason === undefined
         ? undefined

--- a/test/helpers/nativeNanoemOracle.ts
+++ b/test/helpers/nativeNanoemOracle.ts
@@ -30,11 +30,20 @@ export interface NativeNanoemOracleIndexedName {
 export interface NativeNanoemOracleFrame {
   readonly frame: number;
   readonly stages: Partial<Record<NativeNanoemOracleStageName, NativeNanoemOracleStage>>;
+  readonly camera: NativeNanoemOracleCamera | null;
 }
 
 export interface NativeNanoemOracleStage {
   readonly worldMatricesColumnMajor: readonly number[];
   readonly morphWeights: readonly number[];
+}
+
+export interface NativeNanoemOracleCamera {
+  readonly distance: number;
+  readonly position: readonly [number, number, number];
+  readonly rotation: readonly [number, number, number];
+  readonly fov: number;
+  readonly perspective: boolean;
 }
 
 export interface MatrixComparisonIssue {
@@ -102,6 +111,13 @@ export function getOracleStage(
     throw new Error(`Native nanoem oracle stage not found: frame=${frameNumber} stage=${stageName}`);
   }
   return stage;
+}
+
+export function getOracleCamera(
+  dump: NativeNanoemOracleDump,
+  frameNumber: number
+): NativeNanoemOracleCamera | null {
+  return findOracleFrame(dump, frameNumber).camera;
 }
 
 export function getOracleBoneMatrix(
@@ -210,7 +226,8 @@ function parseOracleFrame(raw: unknown, label: string): NativeNanoemOracleFrame 
   }
   return {
     frame: frameNumber,
-    stages: parsedStages
+    stages: parsedStages,
+    camera: parseOracleCamera(frame.camera, `${label}.camera`)
   };
 }
 
@@ -241,6 +258,20 @@ function parseOracleModel(raw: unknown, label: string): NativeNanoemOracleModel 
   };
 }
 
+function parseOracleCamera(raw: unknown, label: string): NativeNanoemOracleCamera | null {
+  if (raw === null || raw === undefined) {
+    return null;
+  }
+  const camera = readRecord(raw, label);
+  return {
+    distance: readFiniteNumber(camera.distance, `${label}.distance`),
+    position: readVec3(camera.position, `${label}.position`),
+    rotation: readVec3(camera.rotation, `${label}.rotation`),
+    fov: readFiniteNumber(camera.fov, `${label}.fov`),
+    perspective: readBoolean(camera.perspective, `${label}.perspective`)
+  };
+}
+
 function parseIndexedNames(raw: unknown, label: string): readonly NativeNanoemOracleIndexedName[] {
   return readArray(raw, label).map((entry, index) => {
     const value = readRecord(entry, `${label}[${index}]`);
@@ -249,6 +280,14 @@ function parseIndexedNames(raw: unknown, label: string): readonly NativeNanoemOr
       name: readString(value.name, `${label}[${index}].name`)
     };
   });
+}
+
+function readVec3(raw: unknown, label: string): [number, number, number] {
+  const values = readNumberArray(raw, label);
+  if (values.length !== 3) {
+    throw new Error(`${label} must have 3 components`);
+  }
+  return [values[0] ?? 0, values[1] ?? 0, values[2] ?? 0];
 }
 
 function sliceMatrix16(
@@ -301,6 +340,13 @@ function readInteger(raw: unknown, label: string): number {
 function readString(raw: unknown, label: string): string {
   if (typeof raw !== "string" || raw.length === 0) {
     throw new Error(`${label} must be a non-empty string`);
+  }
+  return raw;
+}
+
+function readBoolean(raw: unknown, label: string): boolean {
+  if (typeof raw !== "boolean") {
+    throw new Error(`${label} must be a boolean`);
   }
   return raw;
 }

--- a/test/integration/animation/local-camera-oracle.test.ts
+++ b/test/integration/animation/local-camera-oracle.test.ts
@@ -1,0 +1,133 @@
+import { access, readFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { sampleMmdCameraTrackInto, ThreeMmdLoader } from "../../../src/index.js";
+import type { CameraState } from "../../../src/parser/model/modelTypes.js";
+import {
+  compareNumberArrays,
+  getOracleCamera,
+  readNativeNanoemOracleDump
+} from "../../helpers/nativeNanoemOracle.js";
+
+const inventoryPath = "test/fixtures/fixtures.local.json";
+const cameraKey = "addiction-one-person-camera";
+const oraclePath = "test/fixtures/oracles/addiction-one-person-camera.local.json";
+const cameraFixtures = await loadCameraFixtures();
+
+describe("local native nanoem camera oracle", () => {
+  if (cameraFixtures.skipReason) {
+    it.skip(cameraFixtures.skipReason, () => {});
+    return;
+  }
+
+  it(`matches ${cameraKey}`, async () => {
+    const loader = new ThreeMmdLoader();
+    const cameraMotion = await loader.loadAnimation(await readFile(cameraFixtures.cameraMotionPath));
+    const oracle = await readNativeNanoemOracleDump(cameraFixtures.oraclePath);
+
+    for (const { frame } of oracle.frames) {
+      const expected = getOracleCamera(oracle, frame);
+      if (expected === null) {
+        throw new Error(`Camera oracle sample not found: frame=${frame}`);
+      }
+      const actual = sampleMmdCameraTrackInto(
+        cameraMotion.animation.cameraFrames,
+        frame,
+        createCameraStateScratch()
+      );
+      if (!actual) {
+        throw new Error(`Camera runtime sample not found: frame=${frame}`);
+      }
+      const comparison = compareNumberArrays(flattenCameraState(actual), flattenCameraState(expected), 1e-4);
+      expect(comparison.ok, formatCameraMismatch(frame, comparison)).toBe(true);
+    }
+  });
+});
+
+async function loadCameraFixtures(): Promise<
+  | { readonly skipReason: string }
+  | { readonly cameraMotionPath: string; readonly oraclePath: string }
+> {
+  if (!(await fileExists(inventoryPath))) {
+    return { skipReason: `local fixture inventory not found: ${inventoryPath}` };
+  }
+  if (!(await fileExists(oraclePath))) {
+    return { skipReason: `local camera oracle not found: ${oraclePath}` };
+  }
+
+  const inventory = JSON.parse(await readFile(inventoryPath, "utf8")) as {
+    readonly basePath?: string;
+    readonly paths?: {
+      readonly releaseSmoke?: {
+        readonly byExtension?: {
+          readonly cameraVmd?: Record<string, string>;
+        };
+      };
+    };
+  };
+  const cameraPath = inventory.paths?.releaseSmoke?.byExtension?.cameraVmd?.[cameraKey];
+  if (!cameraPath) {
+    return { skipReason: `local camera fixture key not found: ${cameraKey}` };
+  }
+
+  const basePath = resolve(dirname(resolve(inventoryPath)), inventory.basePath ?? ".");
+  const cameraMotionPath = resolve(basePath, cameraPath);
+  if (!(await fileExists(cameraMotionPath))) {
+    return { skipReason: `local camera fixture not found: ${cameraMotionPath}` };
+  }
+
+  return {
+    cameraMotionPath,
+    oraclePath: resolve(oraclePath)
+  };
+}
+
+async function fileExists(path: string): Promise<boolean> {
+  try {
+    await access(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function createCameraStateScratch(): CameraState {
+  return {
+    distance: 0,
+    position: [0, 0, 0],
+    rotation: [0, 0, 0],
+    fov: 1,
+    perspective: true
+  };
+}
+
+function flattenCameraState(camera: {
+  readonly distance: number;
+  readonly position: readonly [number, number, number];
+  readonly rotation: readonly [number, number, number];
+  readonly fov: number;
+  readonly perspective: boolean;
+}): readonly number[] {
+  return [
+    camera.distance,
+    ...camera.position,
+    ...camera.rotation,
+    camera.fov,
+    camera.perspective ? 1 : 0
+  ];
+}
+
+function formatCameraMismatch(
+  frame: number,
+  comparison: ReturnType<typeof compareNumberArrays>
+): string {
+  const worst = comparison.worst;
+  return [
+    `${cameraKey} frame=${frame} maxAbsError=${comparison.maxAbsError}`,
+    worst
+      ? `worst index=${worst.index} expected=${worst.expected} actual=${worst.actual} error=${worst.error}`
+      : "no worst sample"
+  ].join("; ");
+}

--- a/test/integration/animation/local-oracle-playback.test.ts
+++ b/test/integration/animation/local-oracle-playback.test.ts
@@ -2,12 +2,14 @@ import { readFile } from "node:fs/promises";
 
 import { describe, expect, it } from "vitest";
 
-import { ThreeMmdLoader } from "../../../src/index.js";
+import { sampleMmdCameraTrackInto, ThreeMmdLoader } from "../../../src/index.js";
+import type { CameraState } from "../../../src/parser/model/modelTypes.js";
 import { loadLocalPlaybackFixtures } from "../../helpers/localPlaybackFixtures.js";
 import {
   compareNumberArrays,
   extractMmdWorldBoneMatrix,
   findOracleBoneIndex,
+  getOracleCamera,
   getOracleBoneMatrix,
   getOracleStage,
   readNativeNanoemOracleDump
@@ -30,6 +32,10 @@ describe("local native nanoem playback oracle", () => {
       const loader = new ThreeMmdLoader({ runtime: { frameRate: 30, physics: "none" } });
       const model = await loader.loadModel(await readFile(playbackCase.modelPath));
       const motion = await loader.loadAnimation(await readFile(playbackCase.motionPath));
+      const cameraMotion =
+        playbackCase.cameraMotionPath === undefined
+          ? undefined
+          : await loader.loadAnimation(await readFile(playbackCase.cameraMotionPath));
       const oracle = await readNativeNanoemOracleDump(playbackCase.oraclePath);
       const runtime = model.runtime;
       if (!runtime) {
@@ -51,6 +57,27 @@ describe("local native nanoem playback oracle", () => {
           expect(comparison.ok, formatMatrixMismatch(playbackCase.name, frame, boneName, comparison)).toBe(
             true
           );
+        }
+
+        const expectedCamera = getOracleCamera(oracle, frame);
+        if (cameraMotion !== undefined && expectedCamera !== null) {
+          const actualCamera = sampleMmdCameraTrackInto(
+            cameraMotion.animation.cameraFrames,
+            frame,
+            createCameraStateScratch()
+          );
+          if (!actualCamera) {
+            throw new Error(`${playbackCase.name} frame=${frame} camera sample not found`);
+          }
+          const cameraComparison = compareNumberArrays(
+            flattenCameraState(actualCamera),
+            flattenCameraState(expectedCamera),
+            playbackCase.cameraEpsilon
+          );
+          expect(
+            cameraComparison.ok,
+            formatCameraMismatch(playbackCase.name, frame, cameraComparison)
+          ).toBe(true);
         }
 
         const expectedMorphWeights = getOracleStage(
@@ -75,6 +102,32 @@ describe("local native nanoem playback oracle", () => {
   }
 });
 
+function createCameraStateScratch(): CameraState {
+  return {
+    distance: 0,
+    position: [0, 0, 0],
+    rotation: [0, 0, 0],
+    fov: 1,
+    perspective: true
+  };
+}
+
+function flattenCameraState(camera: {
+  readonly distance: number;
+  readonly position: readonly [number, number, number];
+  readonly rotation: readonly [number, number, number];
+  readonly fov: number;
+  readonly perspective: boolean;
+}): readonly number[] {
+  return [
+    camera.distance,
+    ...camera.position,
+    ...camera.rotation,
+    camera.fov,
+    camera.perspective ? 1 : 0
+  ];
+}
+
 function formatMatrixMismatch(
   caseName: string,
   frame: number,
@@ -84,6 +137,20 @@ function formatMatrixMismatch(
   const worst = comparison.worst;
   return [
     `${caseName} frame=${frame} bone=${boneName} maxAbsError=${comparison.maxAbsError}`,
+    worst
+      ? `worst index=${worst.index} expected=${worst.expected} actual=${worst.actual} error=${worst.error}`
+      : "no worst sample"
+  ].join("; ");
+}
+
+function formatCameraMismatch(
+  caseName: string,
+  frame: number,
+  comparison: ReturnType<typeof compareNumberArrays>
+): string {
+  const worst = comparison.worst;
+  return [
+    `${caseName} frame=${frame} camera maxAbsError=${comparison.maxAbsError}`,
     worst
       ? `worst index=${worst.index} expected=${worst.expected} actual=${worst.actual} error=${worst.error}`
       : "no worst sample"

--- a/test/unit/package/PublicApiSmoke.test.ts
+++ b/test/unit/package/PublicApiSmoke.test.ts
@@ -18,7 +18,9 @@ import {
 import {
   DefaultMmdRuntime,
   ThreeMmdLoader,
+  sampleMmdCameraTrackInto,
   createAmmoMmdPhysicsBackend,
+  applyMmdCameraStateToThreeCamera,
   createMmdTextureMapFromFiles,
   createThreeBufferGeometry,
   createThreeSkeleton,
@@ -119,6 +121,11 @@ center
 
   it("exports Three.js adapter geometry helpers from the public barrel", () => {
     expect(createThreeBufferGeometry).toBeTypeOf("function");
+  });
+
+  it("exports Three.js adapter camera helpers from the public barrel", () => {
+    expect(applyMmdCameraStateToThreeCamera).toBeTypeOf("function");
+    expect(sampleMmdCameraTrackInto).toBeTypeOf("function");
   });
 
   it("does not expose Three.js AnimationClip creation from the public barrel", () => {

--- a/test/unit/runtime/CameraLightSampling.test.ts
+++ b/test/unit/runtime/CameraLightSampling.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { sampleMmdCameraTrack, sampleMmdLightTrack } from "../../../src/index.js";
+import { sampleMmdCameraTrack, sampleMmdCameraTrackInto, sampleMmdLightTrack } from "../../../src/index.js";
 import type { VmdCameraFrame, VmdLightFrame } from "../../../src/parser/model/modelTypes.js";
 
 describe("camera and light runtime sampling", () => {
@@ -12,6 +12,75 @@ describe("camera and light runtime sampling", () => {
       position: [5, 10, 15],
       rotation: [0.5, 1, 1.5],
       fov: 52.5,
+      perspective: true
+    });
+  });
+
+  it("samples VMD camera frames into a caller-owned scratch object", () => {
+    const target = {
+      distance: 0,
+      position: [0, 0, 0] as [number, number, number],
+      rotation: [0, 0, 0] as [number, number, number],
+      fov: 1,
+      perspective: true
+    };
+
+    const camera = sampleMmdCameraTrackInto(createCameraFrames(), 5, target);
+
+    expect(camera).toBe(target);
+    expect(target).toEqual({
+      distance: 15,
+      position: [5, 10, 15],
+      rotation: [0.5, 1, 1.5],
+      fov: 52.5,
+      perspective: true
+    });
+  });
+
+  it("advances a caller-owned camera frame index hint during forward sampling", () => {
+    const target = {
+      distance: 0,
+      position: [0, 0, 0] as [number, number, number],
+      rotation: [0, 0, 0] as [number, number, number],
+      fov: 1,
+      perspective: true
+    };
+    const hint = { index: 0 };
+    const frames = [
+      ...createCameraFrames(),
+      {
+        ...createCameraFrames()[1],
+        frame: 20,
+        distance: 30,
+        position: [20, 40, 60] as [number, number, number]
+      }
+    ];
+
+    sampleMmdCameraTrackInto(frames, 15, target, hint);
+
+    expect(hint.index).toBe(1);
+    expect(target.distance).toBe(25);
+    expect(target.position).toEqual([15, 30, 45]);
+  });
+
+  it("holds one-frame camera cuts until the next MMD frame", () => {
+    const frames = createCameraFrames();
+    const camera = sampleMmdCameraTrack(
+      [
+        frames[0],
+        {
+          ...frames[1],
+          frame: 1
+        }
+      ],
+      0.5
+    );
+
+    expect(camera).toMatchObject({
+      distance: 10,
+      position: [0, 0, 0],
+      rotation: [0, 0, 0],
+      fov: 45,
       perspective: true
     });
   });

--- a/test/unit/runtime/DefaultMmdRuntime.test.ts
+++ b/test/unit/runtime/DefaultMmdRuntime.test.ts
@@ -494,6 +494,64 @@ describe("DefaultMmdRuntime", () => {
     expect(Math.abs(ikSource.quaternion.z)).toBeGreaterThan(0.5);
   });
 
+  it("honors VMD property frame IK enable states", () => {
+    const ikSource = new THREE.Bone();
+    ikSource.name = "ikSource";
+    const effector = new THREE.Bone();
+    effector.name = "effector";
+    effector.position.set(1, 0, 0);
+    ikSource.add(effector);
+    const goal = new THREE.Bone();
+    goal.name = "足ＩＫ+";
+    goal.userData.mmdIkStateName = "足ＩＫ";
+    goal.position.set(0, 1, 0);
+    const mesh = new THREE.SkinnedMesh(new THREE.BufferGeometry(), new THREE.MeshBasicMaterial());
+    mesh.add(ikSource, goal);
+    mesh.bind(new THREE.Skeleton([ikSource, effector, goal]));
+    mesh.userData.mmdIkChains = [
+      {
+        goalBoneIndex: 2,
+        effectorBoneIndex: 1,
+        iterationCount: 4,
+        maxAnglePerIteration: Math.PI,
+        links: [{ boneIndex: 0 }]
+      }
+    ];
+    const animation: MmdAnimation = {
+      ...createEmptyMmdAnimation(),
+      propertyFrames: [
+        {
+          frame: 0,
+          visible: true,
+          physicsSimulation: true,
+          ikStates: [{ boneName: "足ＩＫ", enabled: false }]
+        },
+        {
+          frame: 1,
+          visible: true,
+          physicsSimulation: true,
+          ikStates: [{ boneName: "足ＩＫ", enabled: true }]
+        }
+      ]
+    };
+
+    const runtime = new DefaultMmdRuntime();
+    runtime.setAnimation(animation, mesh);
+    runtime.evaluate(0, { physics: false });
+
+    expect(ikSource.quaternion.equals(new THREE.Quaternion())).toBe(true);
+
+    runtime.clearAnimation();
+    runtime.evaluate(0, { physics: false });
+
+    expect(Math.abs(ikSource.quaternion.z)).toBeGreaterThan(0.5);
+
+    runtime.setAnimation(animation, mesh);
+    runtime.evaluate(1 / 30, { physics: false });
+
+    expect(Math.abs(ikSource.quaternion.z)).toBeGreaterThan(0.5);
+  });
+
   it("resets bone pose before rebinding motions so IK does not drift across switches", () => {
     const ikSource = new THREE.Bone();
     ikSource.name = "ikSource";

--- a/test/unit/three/Camera.test.ts
+++ b/test/unit/three/Camera.test.ts
@@ -1,0 +1,186 @@
+import * as THREE from "three";
+import { describe, expect, it } from "vitest";
+
+import { applyMmdCameraStateToThreeCamera } from "../../../src/three/index.js";
+import type { CameraState } from "../../../src/parser/model/modelTypes.js";
+
+describe("Three.js MMD camera helpers", () => {
+  it("applies MMD camera state with the loader coordinate conversion", () => {
+    const camera = new THREE.PerspectiveCamera(30, 1, 0.01, 1000);
+    const target = new THREE.Vector3();
+    const offset = new THREE.Vector3();
+    const euler = new THREE.Euler();
+    const quaternion = new THREE.Quaternion();
+    const up = new THREE.Vector3();
+
+    applyMmdCameraStateToThreeCamera(camera, createCameraState(), {
+      target,
+      offset,
+      euler,
+      quaternion,
+      up
+    });
+
+    expect(camera.position.x).toBeCloseTo(1);
+    expect(camera.position.y).toBeCloseTo(2);
+    expect(camera.position.z).toBeCloseTo(42);
+    expect(camera.fov).toBe(35);
+    expect(camera.userData.mmdCameraPerspective).toBe(true);
+    expect(target.toArray()).toEqual([1, 2, -3]);
+
+    const direction = new THREE.Vector3();
+    camera.getWorldDirection(direction);
+    expect(direction.x).toBeCloseTo(0);
+    expect(direction.y).toBeCloseTo(0);
+    expect(direction.z).toBeCloseTo(-1);
+  });
+
+  it("clamps the perspective camera fov to a positive minimum", () => {
+    const camera = new THREE.PerspectiveCamera(30, 1, 0.01, 1000);
+    const activeCamera = applyMmdCameraStateToThreeCamera(camera, {
+      ...createCameraState(),
+      fov: 0,
+      perspective: false
+    });
+
+    expect(activeCamera).toBe(camera);
+    expect(camera.fov).toBe(1);
+    expect(camera.userData.mmdCameraPerspective).toBe(false);
+  });
+
+  it("switches to an orthographic camera when provided for non-perspective frames", () => {
+    const camera = new THREE.PerspectiveCamera(30, 2, 0.01, 1000);
+    const orthographicCamera = new THREE.OrthographicCamera(-1, 1, 1, -1, 0.01, 1000);
+
+    const activeCamera = applyMmdCameraStateToThreeCamera(
+      camera,
+      {
+        ...createCameraState(),
+        distance: -10,
+        fov: 60,
+        perspective: false
+      },
+      {
+        aspect: 2,
+        orthographicCamera
+      }
+    );
+
+    expect(activeCamera).toBe(orthographicCamera);
+    expect(orthographicCamera.top).toBeCloseTo(5.7735027);
+    expect(orthographicCamera.bottom).toBeCloseTo(-5.7735027);
+    expect(orthographicCamera.right).toBeCloseTo(11.5470054);
+    expect(orthographicCamera.left).toBeCloseTo(-11.5470054);
+    expect(orthographicCamera.userData.mmdCameraPerspective).toBe(false);
+  });
+
+  it("preserves VMD camera roll after aiming at the target", () => {
+    const camera = new THREE.PerspectiveCamera(30, 1, 0.01, 1000);
+    applyMmdCameraStateToThreeCamera(camera, {
+      ...createCameraState(),
+      rotation: [0, 0, Math.PI / 4]
+    });
+
+    const direction = new THREE.Vector3();
+    camera.getWorldDirection(direction);
+    expect(direction.x).toBeCloseTo(0);
+    expect(direction.y).toBeCloseTo(0);
+    expect(direction.z).toBeCloseTo(-1);
+
+    const up = new THREE.Vector3(0, 1, 0).applyQuaternion(camera.quaternion);
+    expect(up.x).toBeCloseTo(Math.SQRT1_2);
+    expect(up.y).toBeCloseTo(Math.SQRT1_2);
+    expect(up.z).toBeCloseTo(0);
+  });
+
+  it("applies MMD camera Y rotation without mirroring the orbit direction", () => {
+    const camera = new THREE.PerspectiveCamera(45, 1, 0.01, 1000);
+    applyMmdCameraStateToThreeCamera(camera, {
+      ...createCameraState(),
+      distance: -10,
+      position: [0, 0, 0],
+      rotation: [0, 0.5, 0]
+    });
+
+    expect(camera.position.x).toBeGreaterThan(0);
+    expect(camera.position.x).toBeCloseTo(4.794255386);
+    expect(camera.position.z).toBeCloseTo(8.775825619);
+
+    const direction = new THREE.Vector3();
+    camera.getWorldDirection(direction);
+    expect(direction.x).toBeLessThan(0);
+    expect(direction.x).toBeCloseTo(-0.479425539);
+    expect(direction.z).toBeCloseTo(-0.877582562);
+  });
+
+  it("matches screen-space projection goldens for inverse MMD camera rotations", () => {
+    const camera = new THREE.PerspectiveCamera(45, 1, 0.01, 1000);
+    applyMmdCameraStateToThreeCamera(camera, {
+      distance: -10,
+      position: [1, 2, 3],
+      rotation: [0.35, 0.45, 0.25],
+      fov: 38,
+      perspective: true
+    });
+    camera.updateMatrixWorld(true);
+
+    expect(projectMmdPoint(camera, [0, 0, 0])).toMatchCloseVector([
+      -0.821613359,
+      -0.425233888,
+      0.997160353
+    ]);
+    expect(projectMmdPoint(camera, [1, 0, 0])).toMatchCloseVector([
+      -0.467049299,
+      -0.345788556,
+      0.997011946
+    ]);
+    expect(projectMmdPoint(camera, [0, 1, 0])).toMatchCloseVector([
+      -0.807165836,
+      -0.044689532,
+      0.997317531
+    ]);
+    expect(projectMmdPoint(camera, [0, 0, 1])).toMatchCloseVector([
+      -0.581605594,
+      -0.506379023,
+      0.997468887
+    ]);
+  });
+});
+
+function createCameraState(): CameraState {
+  return {
+    distance: -45,
+    position: [1, 2, 3],
+    rotation: [0, 0, 0],
+    fov: 35,
+    perspective: true
+  };
+}
+
+function projectMmdPoint(
+  camera: THREE.Camera,
+  point: readonly [number, number, number]
+): readonly number[] {
+  const projected = new THREE.Vector3(point[0], point[1], -point[2]).project(camera);
+  return [projected.x, projected.y, projected.z];
+}
+
+expect.extend({
+  toMatchCloseVector(actual: readonly number[], expected: readonly number[]) {
+    const epsilon = 1e-6;
+    const pass =
+      actual.length === expected.length &&
+      actual.every((value, index) => Math.abs(value - (expected[index] ?? Number.NaN)) <= epsilon);
+    return {
+      pass,
+      message: () =>
+        `expected ${JSON.stringify(actual)} to match ${JSON.stringify(expected)} within ${epsilon}`
+    };
+  }
+});
+
+declare module "vitest" {
+  interface Assertion<T = unknown> {
+    toMatchCloseVector(expected: readonly number[]): T;
+  }
+}

--- a/test/unit/three/Camera.test.ts
+++ b/test/unit/three/Camera.test.ts
@@ -93,6 +93,83 @@ describe("Three.js MMD camera helpers", () => {
     expect(up.z).toBeCloseTo(0);
   });
 
+  it("preserves VMD camera rotation when distance is zero", () => {
+    const camera = new THREE.PerspectiveCamera(30, 1, 0.01, 1000);
+    applyMmdCameraStateToThreeCamera(camera, {
+      ...createCameraState(),
+      distance: 0,
+      rotation: [0.25, 0.5, 0]
+    });
+
+    expect(camera.position.toArray()).toEqual([1, 2, -3]);
+
+    const direction = new THREE.Vector3();
+    camera.getWorldDirection(direction);
+    expect(direction.x).toBeCloseTo(-0.479425539);
+    expect(direction.y).toBeCloseTo(0.217117401);
+    expect(direction.z).toBeCloseTo(-0.850300645);
+  });
+
+  it("aims positive-distance camera frames back at the MMD camera center", () => {
+    const camera = new THREE.PerspectiveCamera(30, 1, 0.01, 1000);
+    applyMmdCameraStateToThreeCamera(camera, {
+      ...createCameraState(),
+      distance: 10,
+      position: [0, 0, 0],
+      rotation: [0, 0, 0]
+    });
+
+    expect(camera.position.toArray()).toEqual([0, 0, -10]);
+
+    const direction = new THREE.Vector3();
+    camera.getWorldDirection(direction);
+    expect(direction.x).toBeCloseTo(0);
+    expect(direction.y).toBeCloseTo(0);
+    expect(direction.z).toBeCloseTo(1);
+  });
+
+  it("adds an outside parent object world position to the MMD camera center", () => {
+    const camera = new THREE.PerspectiveCamera(30, 1, 0.01, 1000);
+    const parent = new THREE.Object3D();
+    const bone = new THREE.Object3D();
+    parent.position.set(10, 20, 30);
+    bone.position.set(1, 2, 3);
+    parent.add(bone);
+    parent.updateMatrixWorld(true);
+
+    applyMmdCameraStateToThreeCamera(
+      camera,
+      {
+        ...createCameraState(),
+        distance: 0,
+        rotation: [0.25, 0.5, 0]
+      },
+      {
+        outsideParent: bone
+      }
+    );
+
+    expect(camera.position.toArray()).toEqual([12, 24, 30]);
+
+    const direction = new THREE.Vector3();
+    camera.getWorldDirection(direction);
+    expect(direction.x).toBeCloseTo(-0.479425539);
+    expect(direction.y).toBeCloseTo(0.217117401);
+    expect(direction.z).toBeCloseTo(-0.850300645);
+  });
+
+  it("adds a precomputed outside parent world position to the MMD camera center", () => {
+    const camera = new THREE.PerspectiveCamera(30, 1, 0.01, 1000);
+
+    applyMmdCameraStateToThreeCamera(camera, createCameraState(), {
+      outsideParentWorldPosition: new THREE.Vector3(10, 20, 30)
+    });
+
+    expect(camera.position.x).toBeCloseTo(11);
+    expect(camera.position.y).toBeCloseTo(22);
+    expect(camera.position.z).toBeCloseTo(72);
+  });
+
   it("applies MMD camera Y rotation without mirroring the orbit direction", () => {
     const camera = new THREE.PerspectiveCamera(45, 1, 0.01, 1000);
     applyMmdCameraStateToThreeCamera(camera, {

--- a/test/unit/three/Dispose.test.ts
+++ b/test/unit/three/Dispose.test.ts
@@ -61,4 +61,42 @@ describe("disposeMmdModel", () => {
     expect(boneTextureDispose).toHaveBeenCalledOnce();
     expect(skeletonDispose).toHaveBeenCalledOnce();
   });
+
+  it("disposes split morph body meshes from the model root object", () => {
+    const geometry = new THREE.BufferGeometry();
+    const bodyGeometry = new THREE.BufferGeometry();
+    const material = new THREE.MeshBasicMaterial();
+    const mesh = new THREE.SkinnedMesh(geometry, material);
+    const bodyMesh = new THREE.SkinnedMesh(bodyGeometry, material);
+    const skeleton = new THREE.Skeleton([new THREE.Bone()]);
+    mesh.bind(skeleton);
+    bodyMesh.bind(skeleton);
+    mesh.userData.mmdMorphSplitBodyMeshes = [bodyMesh];
+
+    const object = new THREE.Group();
+    object.add(mesh, bodyMesh);
+    const scene = new THREE.Scene();
+    scene.add(object);
+
+    const geometryDispose = vi.spyOn(geometry, "dispose");
+    const bodyGeometryDispose = vi.spyOn(bodyGeometry, "dispose");
+    const materialDispose = vi.spyOn(material, "dispose");
+    const skeletonDispose = vi.spyOn(skeleton, "dispose");
+
+    disposeMmdModel({
+      object,
+      mesh,
+      outlineMeshes: [],
+      renderOrderMeshes: [],
+      source: { kind: "bytes", byteLength: 0 },
+      textureDiagnostics: []
+    } satisfies ThreeMmdModel);
+
+    expect(scene.children).toHaveLength(0);
+    expect(object.children).toHaveLength(0);
+    expect(geometryDispose).toHaveBeenCalledOnce();
+    expect(bodyGeometryDispose).toHaveBeenCalledOnce();
+    expect(materialDispose).toHaveBeenCalledOnce();
+    expect(skeletonDispose).toHaveBeenCalledOnce();
+  });
 });

--- a/test/unit/three/Geometry.test.ts
+++ b/test/unit/three/Geometry.test.ts
@@ -4,7 +4,7 @@ import {
   denseMorphProviderSymbol,
   type DenseMorphProvider
 } from "../../../src/parser/model/denseMorphProvider.js";
-import { createThreeBufferGeometry } from "../../../src/three/index.js";
+import { createThreeBufferGeometry, createThreeMorphSplitGeometries } from "../../../src/three/index.js";
 import type { ThreeMmdGeometryBuffers, ThreeMmdGeometryMorph } from "../../../src/three/index.js";
 import type * as THREE from "three";
 
@@ -237,6 +237,65 @@ describe("createThreeBufferGeometry", () => {
       Array.from(geometry.morphAttributes.uv1?.[0]?.array ?? []),
       [0.1, 0.2, 0.3, 0.4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
     );
+  });
+
+  it("splits material geometries so only affected groups carry morph target buffers", () => {
+    const buffers = createQuadBuffers();
+    const splitGeometries = createThreeMorphSplitGeometries(
+      buffers,
+      [
+        { faceCount: 1, materialIndex: 0 },
+        { faceCount: 1, materialIndex: 1 }
+      ],
+      [
+        { vertexOffsets: [{ vertexIndex: 2, position: [0.25, -0.5, 1.5] }] },
+        { groupOffsets: [{ morphIndex: 0, weight: 0.5 }] }
+      ]
+    );
+
+    expect(splitGeometries).toHaveLength(2);
+    expect(splitGeometries.map((split) => split.materialIndex)).toEqual([0, 1]);
+
+    const firstSplit = splitGeometries[0];
+    const secondSplit = splitGeometries[1];
+    if (!firstSplit || !secondSplit) {
+      throw new Error("Expected two split geometries");
+    }
+    const first = firstSplit.geometry;
+    const second = secondSplit.geometry;
+    expect(first.getAttribute("position").count).toBe(3);
+    expect(second.getAttribute("position").count).toBe(3);
+    expect(first.morphAttributes.position).toHaveLength(1);
+    expect(second.morphAttributes.position).toHaveLength(1);
+    expect(Array.from(firstSplit.morphTargetIndices)).toEqual([0]);
+    expect(Array.from(secondSplit.morphTargetIndices)).toEqual([0]);
+    expect(Array.from(first.morphAttributes.position?.[0]?.array ?? [])).toEqual([
+      0, 0, 0, 0, 0, 0, 0.25, -0.5, -1.5
+    ]);
+    expect(Array.from(second.morphAttributes.position?.[0]?.array ?? [])).toEqual([
+      0, 0, 0, 0.25, -0.5, -1.5, 0, 0, 0
+    ]);
+  });
+
+  it("keeps morph-free material split geometries plain", () => {
+    const buffers = createQuadBuffers();
+    const splitGeometries = createThreeMorphSplitGeometries(
+      buffers,
+      [
+        { faceCount: 1, materialIndex: 0 },
+        { faceCount: 1, materialIndex: 1 }
+      ],
+      [{ vertexOffsets: [{ vertexIndex: 1, position: [0.25, -0.5, 1.5] }] }]
+    );
+
+    expect(splitGeometries).toHaveLength(2);
+    const firstSplit = splitGeometries[0];
+    const secondSplit = splitGeometries[1];
+    if (!firstSplit || !secondSplit) {
+      throw new Error("Expected two split geometries");
+    }
+    expect(firstSplit.geometry.morphAttributes.position).toHaveLength(1);
+    expect(secondSplit.geometry.morphAttributes.position).toBeUndefined();
   });
 
   it("rejects malformed geometry buffers before creating Three.js attributes", () => {

--- a/test/unit/three/ThreeMmdLoader.test.ts
+++ b/test/unit/three/ThreeMmdLoader.test.ts
@@ -350,6 +350,7 @@ describe("ThreeMmdLoader", () => {
         effectorBoneIndex: 1
       })
     ]);
+    expect(model.mesh.skeleton.bones[2]?.userData.mmdIkStateName).toBe("enabled IK state");
   });
 
   it("passes PMX fixed-axis links only for hand-twist IK chains", async () => {
@@ -677,12 +678,18 @@ function createIkFlagModel(): MmdModel {
           limitAngle: 1,
           links: [{ boneIndex: 0 }]
         }),
-        createIkFlagBone("enabled IK", 0, true, {
-          targetIndex: 1,
-          loopCount: 1,
-          limitAngle: 1,
-          links: [{ boneIndex: 0 }]
-        })
+        createIkFlagBone(
+          "enabled IK",
+          0,
+          true,
+          {
+            targetIndex: 1,
+            loopCount: 1,
+            limitAngle: 1,
+            links: [{ boneIndex: 0 }]
+          },
+          { ikStateName: "enabled IK state" }
+        )
       ]
     }),
     morphs: () => [],
@@ -739,6 +746,7 @@ function createIkFlagBone(
   ik?: ReturnType<MmdModel["skeleton"]>["bones"][number]["ik"],
   options: {
     readonly fixedAxis?: [number, number, number];
+    readonly ikStateName?: string;
   } = {}
 ): ReturnType<MmdModel["skeleton"]>["bones"][number] {
   return {
@@ -765,6 +773,7 @@ function createIkFlagBone(
       externalParentTransform: false
     },
     fixedAxis: options.fixedAxis,
+    ikStateName: options.ikStateName,
     ik
   };
 }

--- a/test/unit/three/ThreeMmdLoader.test.ts
+++ b/test/unit/three/ThreeMmdLoader.test.ts
@@ -169,6 +169,55 @@ describe("ThreeMmdLoader", () => {
     expect(model.object.children).toEqual([model.mesh]);
   });
 
+  it("splits sparse large morph geometry into local body meshes without dense global morph targets", async () => {
+    const loader = new ThreeMmdLoader({ core: createSparseMorphStressCore() });
+
+    const model = await loader.loadModel(new Uint8Array([1]), {
+      outlines: false,
+      renderOrderProxies: false
+    });
+
+    const bodyMeshes = model.mesh.userData.mmdMorphSplitBodyMeshes as THREE.SkinnedMesh[];
+    expect(bodyMeshes).toHaveLength(2);
+    expect(model.mesh.geometry.morphAttributes.position).toBeUndefined();
+    expect(model.mesh.geometry.drawRange).toEqual({ start: 0, count: 0 });
+    expect(model.object.children).toEqual([model.mesh, ...bodyMeshes]);
+    expect(bodyMeshes.map((mesh) => mesh.morphTargetInfluences?.length)).toEqual([1, 1]);
+    expect(bodyMeshes.map((mesh) => mesh.geometry.morphAttributes.position?.length ?? 0)).toEqual([
+      1,
+      1
+    ]);
+    expect(bodyMeshes.map((mesh) => mesh.renderOrder)).toEqual([0, 2]);
+    expect(bodyMeshes.map((mesh) => mesh.castShadow)).toEqual([true, false]);
+    expect(bodyMeshes.map((mesh) => mesh.receiveShadow)).toEqual([false, true]);
+    expect(bodyMeshes.map((mesh) => Array.from(mesh.userData.mmdMorphSplitBody.morphTargetIndices))).toEqual([
+      [0],
+      [1]
+    ]);
+
+    const sourceInfluences = model.mesh.morphTargetInfluences;
+    if (!sourceInfluences) {
+      throw new Error("Expected source morph influences");
+    }
+    sourceInfluences[0] = 0.25;
+    sourceInfluences[1] = 0.75;
+    bodyMeshes.forEach((mesh) => {
+      const material = Array.isArray(mesh.material) ? mesh.material[0] : mesh.material;
+      if (!material) {
+        throw new Error("Expected split mesh material");
+      }
+      mesh.onBeforeRender(
+        {} as THREE.WebGLRenderer,
+        {} as THREE.Scene,
+        {} as THREE.Camera,
+        mesh.geometry,
+        material,
+        null
+      );
+    });
+    expect(bodyMeshes.map((mesh) => mesh.morphTargetInfluences?.[0])).toEqual([0.25, 0.75]);
+  });
+
   it("applies load-time frustum culling to the mesh and generated proxy meshes", async () => {
     const loader = new ThreeMmdLoader();
 
@@ -631,6 +680,134 @@ function createIkFlagCore(): MmdCore {
       morphs: {}
     }),
     loadVpdAnimation: () => createEmptyMmdAnimation()
+  };
+}
+
+function createSparseMorphStressCore(): MmdCore {
+  const model = createSparseMorphStressModel();
+  return {
+    version: () => "sparse-morph-stress-core",
+    healthCheck: () => true,
+    loadModel: () => model,
+    loadVmd: () => createEmptyMmdAnimation(),
+    loadVpd: () => ({
+      kind: "vpd",
+      bytes: new Uint8Array(),
+      metadata: { modelFile: "", boneCount: 0, morphCount: 0 },
+      bones: {},
+      morphs: {}
+    }),
+    loadVpdAnimation: () => createEmptyMmdAnimation()
+  };
+}
+
+function createSparseMorphStressModel(): MmdModel {
+  const vertexCount = 6000;
+  const positions = new Float32Array(vertexCount * 3);
+  const normals = new Float32Array(vertexCount * 3);
+  const uvs = new Float32Array(vertexCount * 2);
+  const skinIndices = new Uint16Array(vertexCount * 4);
+  const skinWeights = new Float32Array(vertexCount * 4);
+  for (let vertexIndex = 0; vertexIndex < vertexCount; vertexIndex += 1) {
+    const positionBase = vertexIndex * 3;
+    positions[positionBase] = vertexIndex % 100;
+    positions[positionBase + 1] = Math.floor(vertexIndex / 100);
+    normals[positionBase + 1] = 1;
+    const skinBase = vertexIndex * 4;
+    skinWeights[skinBase] = 1;
+  }
+  const morphs = Array.from({ length: 1000 }, (_, index) => ({
+    name: `morph${index}`,
+    englishName: `morph${index}`,
+    type: "vertex" as const,
+    vertexOffsets:
+      index === 0
+        ? [{ vertexIndex: 1, position: [0.1, 0, 0] as [number, number, number] }]
+        : index === 1
+          ? [{ vertexIndex: 3001, position: [0, 0.2, 0] as [number, number, number] }]
+          : [],
+    groupOffsets: [],
+    boneOffsets: [],
+    uvOffsets: [],
+    additionalUvOffsets: [],
+    materialOffsets: []
+  }));
+  return {
+    metadata: () => ({
+      format: "pmx",
+      version: 2,
+      encoding: "utf-8",
+      name: "sparse morph stress",
+      englishName: "SparseMorphStress",
+      comment: "",
+      englishComment: "",
+      counts: {
+        vertices: vertexCount,
+        faces: 2,
+        materials: 2,
+        bones: 1,
+        morphs: morphs.length,
+        displayFrames: 0,
+        rigidBodies: 0,
+        joints: 0,
+        softBodies: 0
+      },
+      indexSizes: { vertex: 2, texture: 1, material: 1, bone: 1, morph: 2, rigidBody: 1 },
+      additionalUvCount: 0,
+      diagnostics: []
+    }),
+    geometry: () => ({
+      positions,
+      normals,
+      uvs,
+      additionalUvs: [],
+      indices: new Uint16Array([0, 1, 2, 3000, 3001, 3002]),
+      materialGroups: [
+        { start: 0, count: 3, materialIndex: 0 },
+        { start: 3, count: 3, materialIndex: 1 }
+      ],
+      skinIndices,
+      skinWeights
+    }),
+    materials: () => [createStressMaterial(0), createStressMaterial(1)],
+    skeleton: () => ({
+      bones: [createIkFlagBone("root", -1, true)]
+    }),
+    morphs: () => morphs,
+    displayFrames: () => [],
+    rigidBodies: () => [],
+    joints: () => [],
+    softBodies: () => [],
+    embeddedTextures: () => []
+  };
+}
+
+function createStressMaterial(index: number): ReturnType<MmdModel["materials"]>[number] {
+  return {
+    name: `mat${index}`,
+    englishName: `mat${index}`,
+    texturePath: "",
+    sphereTexturePath: "",
+    sphereMode: "none",
+    toonTexturePath: "",
+    sharedToonIndex: undefined,
+    diffuse: [0.8, 0.8, 0.8, 1],
+    specular: [0, 0, 0],
+    specularPower: 1,
+    ambient: [0.2, 0.2, 0.2],
+    edgeColor: [0, 0, 0, 1],
+    edgeSize: 0,
+    flags: {
+      doubleSided: false,
+      groundShadow: false,
+      selfShadowMap: index === 0,
+      selfShadow: index === 1,
+      edge: false,
+      vertexColor: false,
+      pointDraw: false,
+      lineDraw: false
+    },
+    faceCount: 1
   };
 }
 

--- a/test/unit/viewer/ViewerSource.test.ts
+++ b/test/unit/viewer/ViewerSource.test.ts
@@ -33,9 +33,15 @@ describe("example viewer source", () => {
     const domSource = await readFile("examples/viewer/lib/dom.js", "utf8");
     const modelSource = await readFile("examples/viewer/lib/model-loading.js", "utf8");
     const stateSource = await readFile("examples/viewer/lib/state.js", "utf8");
+    const configSource = await readFile("examples/viewer/lib/viewer-config.js", "utf8");
     const html = await readFile("examples/viewer/index.html", "utf8");
     const styles = await readFile("examples/viewer/styles.css", "utf8");
 
+    expect(configSource).toContain('query.get("mmdFrameRate")');
+    expect(configSource).toContain('query.get("mmdFrameQuantize")');
+    expect(stateSource).toContain("frameRate: viewerConfig.mmdFrameRate");
+    expect(stateSource).toContain("mmdFrameRate: viewerConfig.mmdFrameRate");
+    expect(stateSource).toContain("mmdFrameQuantize: viewerConfig.mmdFrameQuantize");
     expect(html).toContain('id="model-switcher"');
     expect(html).not.toContain('id="model-name"');
     expect(html).toContain('aria-label="Selected model"');
@@ -193,6 +199,9 @@ describe("example viewer source", () => {
     expect(serverSource).toContain("backgroundPmd");
     expect(serverSource).toContain("audios");
     expect(serverSource).toContain("cameras");
+    expect(serverSource).toContain("fixtureCase.background?.extension");
+    expect(serverSource).toContain("fixtureCase.camera?.key");
+    expect(serverSource).toContain("fixtureCase.audio?.extension");
     expect(serverSource).toContain("process.env.MMD_DATA_ROOT");
     expect(serverSource).not.toContain("MMD_VIEWER_DATA_ROOT");
     expect(styles).toContain(".asset-load-row");
@@ -238,17 +247,30 @@ describe("example viewer source", () => {
     expect(cameraSource).toContain("syncTimelineRangeToCurrentMotion()");
     expect(cameraSource).toContain("currentMotionDurationSeconds()");
     expect(cameraSource).not.toContain("existingMax");
-    expect(cameraSource).not.toContain("sampleMmdCameraTrack");
-    expect(cameraSource).toContain("function interpolateBezier");
-    expect(cameraSource).toContain("function cubicBezier");
-    expect(cameraSource).toContain("-lerp(previous.position[2], next.position[2]");
-    expect(cameraSource).toContain("-lerp(previous.rotation[0], next.rotation[0]");
-    expect(cameraSource).toContain("offset.set(0, 0, -distance)");
+    expect(cameraSource).toContain("cameraMotion.frameIndexHint");
+    expect(cameraSource).toContain("currentMmdFrame()");
+    expect(cameraSource).toContain("/ state.mmdFrameRate");
+    expect(cameraSource).toContain("applyMmdCameraStateToThreeCamera(");
+    expect(cameraSource).toContain("state.perspectiveCamera");
+    expect(cameraSource).toContain("state.controls.object = activeCamera");
+    expect(cameraSource).not.toContain("function interpolateBezier");
+    expect(cameraSource).not.toContain("function cubicBezier");
     expect(cameraSource).not.toContain("function cameraFrameAt");
     expect(playbackSource).toContain("applyCameraMotion()");
+    expect(playbackSource).toContain("currentMmdSeconds()");
+    expect(modelSource).toContain("frameRate: state.mmdFrameRate");
     expect(stateSource).toContain("currentBackground: undefined");
     expect(stateSource).toContain("currentCameraMotion: undefined");
+    expect(stateSource).toContain("mmdFrameQuantize");
+    expect(stateSource).toContain("export function currentMmdFrame()");
+    expect(stateSource).toContain("state.mmdFrameQuantize ? Math.floor");
     expect(stateSource).toContain("cameraTargetScratch: new THREE.Vector3()");
+    expect(stateSource).toContain("cameraQuaternionScratch: new THREE.Quaternion()");
+    expect(stateSource).toContain("quaternion: state.cameraQuaternionScratch");
+    expect(stateSource).toContain("cameraStateScratch: {");
+    expect(stateSource).toContain("orthographicCamera: undefined");
+    expect(stateSource).toContain("get orthographicCamera()");
+    expect(stateSource).toContain("state.cameraApplyOptions = {");
   });
 
   it("keeps audio playback resume from seeking back to the start", async () => {

--- a/test/unit/viewer/ViewerSource.test.ts
+++ b/test/unit/viewer/ViewerSource.test.ts
@@ -8,9 +8,24 @@ describe("example viewer source", () => {
     const disposeSource = await readFile("examples/viewer/lib/dispose.js", "utf8");
 
     expect(modelSource).toContain("disposeModelResources(state.currentModel)");
+    expect(modelSource).toContain("state.scene.remove(state.currentModel.object)");
     expect(disposeSource).toContain('import { disposeMmdModel } from "../../../dist/three/index.js"');
     expect(disposeSource).toContain("disposeMmdModel(model)");
     expect(disposeSource).not.toContain("function collectMaterialTextures(material)");
+  });
+
+  it("adds loader root objects so split morph body meshes are rendered", async () => {
+    const modelSource = await readFile("examples/viewer/lib/model-loading.js", "utf8");
+    const backgroundSource = await readFile("examples/viewer/lib/background-loading.js", "utf8");
+    const realModelVisualSource = await readFile("scripts/visual-regression/render-real-models.mjs", "utf8");
+
+    expect(modelSource).toContain("state.scene.add(model.object)");
+    expect(modelSource).not.toContain("state.scene.add(\n    model.mesh");
+    expect(backgroundSource).toContain("state.scene.add(background.object)");
+    expect(backgroundSource).toContain("state.scene.remove(state.currentBackground.object)");
+    expect(realModelVisualSource).toContain("scene.add(model.object)");
+    expect(realModelVisualSource).toContain("createCamera(visualCase.camera, model.object");
+    expect(realModelVisualSource).not.toContain("scene.add(model.mesh, ...model.renderOrderMeshes, ...model.outlineMeshes)");
   });
 
   it("surfaces texture diagnostics from loaded models", async () => {


### PR DESCRIPTION
## Summary

- split large sparse geometry morphs into per-material body meshes so the parent mesh no longer allocates dense global position morph targets
- keep the public parent mesh morph influence API and sync only needed influences to each body mesh before render
- route viewer and visual regression rendering through the model root object so split body meshes are rendered
- preserve material render order, shadow flags, disposal, and regression coverage for split body meshes

## Validation

- `rtk npm run build`
- `rtk npm test -- test/unit/three/ThreeMmdLoader.test.ts`
- `rtk npm test -- test/unit/three/Dispose.test.ts test/unit/three/ThreeMmdLoader.test.ts`
- `rtk npm test -- test/unit/viewer/ViewerSource.test.ts -t "adds loader root objects"`
- `rtk npx eslint src/three/dispose.ts test/unit/three/Dispose.test.ts test/unit/viewer/ViewerSource.test.ts --max-warnings 0`
- `rtk npx eslint src/three/index.ts test/unit/three/ThreeMmdLoader.test.ts --max-warnings 0`

## Notes

The local viewer working tree still has unrelated unstaged changes and is intentionally not included in this PR.