### PR TITLE
docs(changelog): align renderer switch behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,9 +28,8 @@ All notable changes to this project will be documented in this file.
 - Expose the structured PMM document and project-summary types from the parser
   entry point, and represent nullable fields from the WASM JSON contract
   explicitly in the public TypeScript types.
-- Preserve the active camera when loading a model or switching renderer
-  backends, and adapt viewer near/far planes to scene bounds without moving the
-  camera.
+- Preserve the active camera when loading a model, and adapt viewer near/far
+  planes to scene bounds without moving the camera.
 - Consolidate duplicated viewer backend parameters, model-load guards, sparse
   morph builders, and visual-regression helpers.
 


### PR DESCRIPTION
## Summary

- remove the stale claim that renderer backend switching preserves the active camera
- keep the valid statement that model loading preserves the active camera

## Why

The renderer-switch state preservation feature was intentionally removed before the v0.7.0 release. The merged changelog still described the old behavior, so tagging v0.7.0 would publish an inaccurate release note.

## Impact

Documentation-only correction. Runtime and package contents are unchanged.

## Validation

- `git diff --check`
- verified `package.json`, `package-lock.json`, and viewer metadata remain at `0.7.0`

This PR must merge before creating and pushing the `v0.7.0` tag.