### PR TITLE
fix(ci): build release artifacts before tests

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,11 +43,11 @@ jobs:
       - name: Lint
         run: npm run lint
 
-      - name: Test
-        run: npm test
-
       - name: Build
         run: npm run build
+
+      - name: Test
+        run: npm test
 
       - name: Check fixtures
         run: npm run check:fixtures


### PR DESCRIPTION
## Summary

- Move the release workflow build step before `npm test`.
- Keep the tag-driven release package validation aligned with the normal CI order.

## Root cause

The first `v0.8.0` release run (`30730747557`) failed in `WorkerMmdRuntime.test.ts` because the clean checkout had not generated `dist/worker/node-entry.js` before tests ran. npm publish and GitHub Release creation were skipped.

## Validation

- `npm run lint`
- `npm run build`
- `npm test` — 82 files, 760 passed, 5 skipped
- `git diff --check`

## Release recovery

The existing `v0.8.0` annotated tag is intentionally retained at merge commit `2106ef32`; it was pushed but not published. After this PR is merged, rerun `release.yml` from `main` with `publish=true`, then verify npm and the GitHub Release.