### PR TITLE
chore(release): prepare v0.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+## [0.8.1] - 2026-08-03
+
+### Fixed
+
+- Prevent TSL Viewer Grid and Axis visibility toggles from synchronously
+  re-entering the renderer and stalling the main thread.
+- Precompile TSL color and dedicated self-shadow shader variants
+  asynchronously, coalescing overlapping requests during model and
+  background loading and view toggles.
+
 ## [0.8.0] - 2026-07-30
 
 ### Added

--- a/examples/viewer/index.html
+++ b/examples/viewer/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="description" content="Load and play MikuMikuDance (MMD) models (PMX/PMD) and motions (VMD) with physics, right in your browser. Files stay on your device — nothing is uploaded." />
-    <meta name="mmd-viewer-version" content="0.8.0" />
+    <meta name="mmd-viewer-version" content="0.8.1" />
     <title>MMD Loader for Three.js · three-mmd-loader</title>
     <link rel="icon" href="data:," />
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Rounded" />

--- a/examples/viewer/lib/background-loading.js
+++ b/examples/viewer/lib/background-loading.js
@@ -97,7 +97,7 @@ async function loadBackground(source, label, loaderFactory, entry) {
     });
     updateStageState();
     setStatus("", "ready");
-    await renderStillFrame();
+    await renderStillFrame({ compileShaders: isTslViewerPipeline() });
     if (generation !== backgroundLoadGeneration || state.currentBackground !== background) {
       return false;
     }

--- a/examples/viewer/lib/model-loading.js
+++ b/examples/viewer/lib/model-loading.js
@@ -244,7 +244,7 @@ export async function loadModel(source, label = source.name ?? "model", modelLoa
     if (state.showDebugColliders) {
       showColliderHelpers();
     }
-    await renderStillFrame();
+    await renderStillFrame({ compileShaders: isTslViewerPipeline() });
     if (!isCurrentLoad()) {
       loadProfile?.mark("cancelled");
       return false;
@@ -383,7 +383,7 @@ export async function loadModelFolder(files, loadOptions = {}) {
     if (state.showDebugColliders) {
       showColliderHelpers();
     }
-    await renderStillFrame();
+    await renderStillFrame({ compileShaders: isTslViewerPipeline() });
     if (!isCurrentLoad()) {
       profile?.mark("cancelled");
       return;
@@ -490,7 +490,7 @@ export async function switchFolderModel(modelFile, loadOptions = {}) {
     if (state.showDebugColliders) {
       showColliderHelpers();
     }
-    await renderStillFrame();
+    await renderStillFrame({ compileShaders: isTslViewerPipeline() });
     if (!isCurrentLoad()) {
       profile?.mark("cancelled");
       return;

--- a/examples/viewer/lib/playback.js
+++ b/examples/viewer/lib/playback.js
@@ -22,6 +22,7 @@ import { updateSelfShadowDepthBias, updateShadowCameraForFrame } from "./scene-s
 import {
   isTslViewerPipeline,
   submitViewerRender,
+  submitViewerRenderAsync,
   syncMmdTslDedicatedShadowMode,
   syncMmdTslDedicatedShadowVisibility,
   syncViewerTslLight,
@@ -32,6 +33,7 @@ let settledRenderPromise;
 let settledRenderPending = false;
 let settledRenderPhysics;
 let settledRenderIk;
+let settledRenderCompileShaders = false;
 let settledEvaluationInFlight = 0;
 
 export function render() {
@@ -72,6 +74,7 @@ export function renderStillFrame(options) {
   settledRenderPending = true;
   settledRenderPhysics = options?.physics;
   settledRenderIk = options?.ik;
+  settledRenderCompileShaders ||= options?.compileShaders === true;
   if (!settledRenderPromise) {
     settledRenderPromise = drainSettledRenders();
     void settledRenderPromise.catch(reportSettledRenderError);
@@ -98,8 +101,10 @@ async function drainSettledRenders() {
       settledRenderPending = false;
       const options = {
         physics: settledRenderPhysics,
-        ik: settledRenderIk
+        ik: settledRenderIk,
+        compileShaders: settledRenderCompileShaders
       };
+      settledRenderCompileShaders = false;
       try {
         await renderSettledFrame(options);
       } catch (error) {
@@ -115,6 +120,7 @@ async function drainSettledRenders() {
     settledRenderPending = false;
     settledRenderPhysics = undefined;
     settledRenderIk = undefined;
+    settledRenderCompileShaders = false;
     settledRenderPromise = undefined;
   }
 }
@@ -142,7 +148,11 @@ async function renderSettledFrame(options) {
       updateColliderHelpers();
       state.controls.update();
       applyCameraMotion();
-      submitViewerRender();
+      if (options.compileShaders && isTslViewerPipeline()) {
+        await submitViewerRenderAsync();
+      } else {
+        submitViewerRender();
+      }
     } finally {
       state.elapsedSeconds = resumeSeconds;
     }

--- a/examples/viewer/lib/scene-setup.js
+++ b/examples/viewer/lib/scene-setup.js
@@ -129,7 +129,6 @@ export function setViewportGridVisible(visible) {
     state.gridHelper.visible = state.viewportGridVisible;
   }
   persistViewportSettings();
-  state.renderer?.render(state.scene, state.camera);
   return state.viewportGridVisible;
 }
 
@@ -139,7 +138,6 @@ export function setViewportAxesVisible(visible) {
     state.axesHelper.visible = state.viewportAxesVisible;
   }
   persistViewportSettings();
-  state.renderer?.render(state.scene, state.camera);
   return state.viewportAxesVisible;
 }
 

--- a/examples/viewer/lib/viewer-pipeline.js
+++ b/examples/viewer/lib/viewer-pipeline.js
@@ -229,6 +229,8 @@ export function submitViewerRender(skipIfCompiling = false) {
 
 let viewerRenderToken = 0;
 let viewerRenderCompileToken = 0;
+let viewerRenderCompilePromise;
+let viewerRenderCompileRequest = 0;
 
 // Debug-panel view toggles (selfShadow, normals) flip a renderer/material
 // parameter that changes every currently-visible material's compiled shader
@@ -252,7 +254,7 @@ export async function submitViewerRenderAsync() {
     setStatus("Compiling shaders…", "loading");
   }
   try {
-    await state.renderer.compileAsync(state.scene, state.camera);
+    await compileViewerShaders();
   } catch (error) {
     window.console?.warn?.(
       "[mmd-viewer] async shader precompile failed, falling back to a synchronous render",
@@ -272,6 +274,54 @@ export async function submitViewerRenderAsync() {
     return false;
   }
   return submitViewerRender();
+}
+
+function compileViewerShaders() {
+  viewerRenderCompileRequest += 1;
+  if (!viewerRenderCompilePromise) {
+    viewerRenderCompilePromise = (async () => {
+      while (true) {
+        const request = viewerRenderCompileRequest;
+        await compileViewerColorShaders();
+        await compileViewerSelfShadowShaders();
+        if (request === viewerRenderCompileRequest) {
+          return;
+        }
+      }
+    })().finally(() => {
+      viewerRenderCompilePromise = undefined;
+    });
+  }
+  return viewerRenderCompilePromise;
+}
+
+async function compileViewerColorShaders() {
+  const shadowMapEnabled = state.renderer.shadowMap.enabled;
+  const dedicatedSelfShadowActive =
+    isTslViewerPipeline() &&
+    state.debugSelfShadowEnabled &&
+    state.keyLight?.castShadow === true;
+  if (dedicatedSelfShadowActive) {
+    state.renderer.shadowMap.enabled = false;
+  }
+  try {
+    await state.renderer.compileAsync(state.scene, state.camera);
+  } finally {
+    state.renderer.shadowMap.enabled = shadowMapEnabled;
+  }
+}
+
+async function compileViewerSelfShadowShaders() {
+  if (!state.debugSelfShadowEnabled || state.keyLight?.castShadow !== true) {
+    return;
+  }
+  if (isNativeTslWebGpuPipeline()) {
+    await mmdTslPipeline?.compileAsync?.(state.scene);
+    return;
+  }
+  if (mmdTslSelfShadowPass) {
+    await mmdTslSelfShadowPass.compileAsync(state.renderer, state.scene, state.keyLight);
+  }
 }
 
 export function disposeViewerPipelineModel(model) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@yohawing/three-mmd-loader",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@yohawing/three-mmd-loader",
-      "version": "0.8.0",
+      "version": "0.8.1",
       "license": "MIT",
       "dependencies": {
         "@types/three": ">=0.176.0 <1.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yohawing/three-mmd-loader",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "TypeScript-first ESM library for Three.js MMD loading and playback.",
   "type": "module",
   "license": "MIT",

--- a/src/webgpu/pipeline.ts
+++ b/src/webgpu/pipeline.ts
@@ -96,6 +96,10 @@ interface MmdTslAttachedModel {
   readonly sparseMorphs: boolean;
 }
 
+interface MmdTslPipelineInternal extends MmdTslPipeline {
+  compileAsync(scene: THREE.Scene): Promise<boolean>;
+}
+
 interface TslOutlineMetadata {
   readonly sourceMaterialIndex?: number;
   readonly fallback?: boolean;
@@ -181,7 +185,7 @@ function createInitializedPipeline(
   let selfShadowMode: 0 | 1 | 2 = options.selfShadowMode ?? 1;
   let disposed = false;
 
-  const pipeline: MmdTslPipeline = {
+  const pipeline: MmdTslPipelineInternal = {
     renderer,
     get light() {
       return light;
@@ -320,6 +324,12 @@ function createInitializedPipeline(
         syncReceiverVisibility(state);
       }
       return true;
+    },
+    async compileAsync(scene) {
+      if (!selfShadowPass || !light || !selfShadowEnabled || light.castShadow !== true) {
+        return false;
+      }
+      return selfShadowPass.compileAsync(renderer, scene, light);
     },
     render(scene, camera) {
       if (disposed) {

--- a/src/webgpu/self-shadow-pass.ts
+++ b/src/webgpu/self-shadow-pass.ts
@@ -13,6 +13,7 @@ export interface MmdTslSelfShadowPass {
    * every other value (including disabled/missing state) safely uses mode 1.
    */
   setMode(mode: number): boolean;
+  compileAsync(renderer: THREE.WebGPURenderer, scene: THREE.Scene, light: THREE.DirectionalLight): Promise<boolean>;
   render(renderer: THREE.WebGPURenderer, scene: THREE.Scene, light: THREE.DirectionalLight): boolean;
   setReceiverVisibilityDebug(root: THREE.Object3D, enabled: boolean, sampleTarget?: boolean): boolean;
   dispose(): void;
@@ -70,6 +71,68 @@ export function createMmdTslSelfShadowPass(
   ) => void;
   let disposed = false;
 
+  function prepareShadowRender(
+    currentRenderer: THREE.WebGPURenderer,
+    scene: THREE.Scene,
+    currentLight: THREE.DirectionalLight
+  ): { shadowCamera: THREE.Camera; restore: () => void } | undefined {
+    if (
+      disposed ||
+      currentRenderer !== renderer ||
+      currentLight !== light ||
+      currentLight.castShadow !== true
+    ) {
+      return undefined;
+    }
+
+    const shadowCamera = currentLight.shadow.camera;
+    const originalLayerMask = shadowCamera.layers.mask;
+    const originalShadowMapEnabled = currentRenderer.shadowMap.enabled;
+    if (shadowCamera.coordinateSystem !== currentRenderer.coordinateSystem) {
+      shadowCamera.coordinateSystem = currentRenderer.coordinateSystem;
+      shadowCamera.updateProjectionMatrix();
+    }
+    // Three's common Renderer only flips a camera's projection matrix to the
+    // reversed-depth form lazily, the first time that camera is passed to
+    // renderer.render() (node_modules/three/src/renderers/common/
+    // Renderer.js ~line 1516). Update the flag before LightShadow bakes its
+    // matrix so the first async compile and the first real pass agree.
+    const wantsReversedDepth = currentRenderer.reversedDepthBuffer === true;
+    if (shadowCamera.reversedDepth !== wantsReversedDepth) {
+      (shadowCamera as unknown as { _reversedDepth: boolean })._reversedDepth = wantsReversedDepth;
+      shadowCamera.updateProjectionMatrix();
+    }
+    currentLight.shadow.updateMatrices(currentLight);
+
+    resetRendererAndSceneState(currentRenderer, scene, rendererState);
+    try {
+      currentRenderer.shadowMap.enabled = false;
+      shadowCamera.layers.mask = 1 << MMD_SELF_SHADOW_LAYER;
+      scene.overrideMaterial = shadowMaterial;
+      currentRenderer.setRenderTarget(renderTarget);
+      currentRenderer.setClearColor(0x000000, 0);
+      currentRenderer.setRenderObjectFunction(shadowRenderObjectFunction);
+      let restored = false;
+      return {
+        shadowCamera,
+        restore() {
+          if (restored) {
+            return;
+          }
+          restored = true;
+          shadowCamera.layers.mask = originalLayerMask;
+          currentRenderer.shadowMap.enabled = originalShadowMapEnabled;
+          restoreRendererAndSceneState(currentRenderer, scene, rendererState);
+        }
+      };
+    } catch (error) {
+      shadowCamera.layers.mask = originalLayerMask;
+      currentRenderer.shadowMap.enabled = originalShadowMapEnabled;
+      restoreRendererAndSceneState(currentRenderer, scene, rendererState);
+      throw error;
+    }
+  }
+
   return {
     renderTarget,
     depthTexture,
@@ -82,60 +145,31 @@ export function createMmdTslSelfShadowPass(
       shadowModeUniform.value = nextMode;
       return true;
     },
-    render(currentRenderer, scene, currentLight) {
-      if (
-        disposed ||
-        currentRenderer !== renderer ||
-        currentLight !== light ||
-        currentLight.castShadow !== true
-      ) {
+    async compileAsync(currentRenderer, scene, currentLight) {
+      if (typeof currentRenderer.compileAsync !== "function") {
         return false;
       }
-
-      const shadowCamera = currentLight.shadow.camera;
-      const originalLayerMask = shadowCamera.layers.mask;
-      const originalShadowMapEnabled = currentRenderer.shadowMap.enabled;
-      if (shadowCamera.coordinateSystem !== currentRenderer.coordinateSystem) {
-        shadowCamera.coordinateSystem = currentRenderer.coordinateSystem;
-        shadowCamera.updateProjectionMatrix();
+      const prepared = prepareShadowRender(currentRenderer, scene, currentLight);
+      if (!prepared) {
+        return false;
       }
-      // Three's common Renderer only flips a camera's projection matrix to
-      // the reversed-depth form lazily, the first time that camera is passed
-      // to renderer.render() (node_modules/three/src/renderers/common/
-      // Renderer.js ~line 1516: `if (this.reversedDepthBuffer === true &&
-      // camera.reversedDepth !== true) { camera._reversedDepth = true; ...
-      // camera.updateProjectionMatrix(); }`). DirectionalLightShadow.
-      // updateMatrices() below (node_modules/three/src/lights/LightShadow.js
-      // ~line 213) bakes `shadowCamera.projectionMatrix` into `shadow.matrix`
-      // immediately, using whatever matrix is on the camera *right now* --
-      // it does not defer. Left to the lazy path, the very first frame would
-      // bake a non-reversed shadow.matrix while the actual render call flips
-      // the camera to reversed afterward, producing one frame of mismatched
-      // depth comparisons. Sync the flag proactively (mirroring the
-      // renderer's own `_reversedDepth` field, which has no public setter)
-      // so updateMatrices always sees the projection that will actually be
-      // used to render the depth target.
-      const wantsReversedDepth = currentRenderer.reversedDepthBuffer === true;
-      if (shadowCamera.reversedDepth !== wantsReversedDepth) {
-        (shadowCamera as unknown as { _reversedDepth: boolean })._reversedDepth = wantsReversedDepth;
-        shadowCamera.updateProjectionMatrix();
-      }
-      currentLight.shadow.updateMatrices(currentLight);
-
-      resetRendererAndSceneState(currentRenderer, scene, rendererState);
       try {
-        currentRenderer.shadowMap.enabled = false;
-        shadowCamera.layers.mask = 1 << MMD_SELF_SHADOW_LAYER;
-        scene.overrideMaterial = shadowMaterial;
-        currentRenderer.setRenderTarget(renderTarget);
-        currentRenderer.setClearColor(0x000000, 0);
-        currentRenderer.setRenderObjectFunction(shadowRenderObjectFunction);
-        currentRenderer.render(scene, shadowCamera);
+        await currentRenderer.compileAsync(scene, prepared.shadowCamera);
         return true;
       } finally {
-        shadowCamera.layers.mask = originalLayerMask;
-        currentRenderer.shadowMap.enabled = originalShadowMapEnabled;
-        restoreRendererAndSceneState(currentRenderer, scene, rendererState);
+        prepared.restore();
+      }
+    },
+    render(currentRenderer, scene, currentLight) {
+      const prepared = prepareShadowRender(currentRenderer, scene, currentLight);
+      if (!prepared) {
+        return false;
+      }
+      try {
+        currentRenderer.render(scene, prepared.shadowCamera);
+        return true;
+      } finally {
+        prepared.restore();
       }
     },
     setReceiverVisibilityDebug(root, enabled, sampleTarget = true) {

--- a/test/unit/viewer/ViewerSource.test.ts
+++ b/test/unit/viewer/ViewerSource.test.ts
@@ -153,12 +153,21 @@ describe("example viewer source", () => {
     const pipelineSource = await readFile("examples/viewer/lib/viewer-pipeline.js", "utf8");
     const modelSource = await readFile("examples/viewer/lib/model-loading.js", "utf8");
     const backgroundSource = await readFile("examples/viewer/lib/background-loading.js", "utf8");
+    const sceneSource = await readFile("examples/viewer/lib/scene-setup.js", "utf8");
 
     expect(pipelineSource).toContain("export async function submitViewerRenderAsync()");
     expect(pipelineSource).toContain("typeof state.renderer?.compileAsync === \"function\"");
     expect(pipelineSource).toContain("await state.renderer.compileAsync(state.scene, state.camera)");
     expect(pipelineSource).toContain("if (!canCompileAsync) {\n    return submitViewerRender();\n  }");
     expect(pipelineSource).toContain("let viewerRenderCompileToken = 0;");
+    expect(pipelineSource).toContain("let viewerRenderCompilePromise;");
+    expect(pipelineSource).toContain("let viewerRenderCompileRequest = 0;");
+    expect(pipelineSource).toContain("function compileViewerShaders()");
+    expect(pipelineSource).toContain("function compileViewerColorShaders()");
+    expect(pipelineSource).toContain("function compileViewerSelfShadowShaders()");
+    expect(pipelineSource).toContain("const dedicatedSelfShadowActive");
+    expect(pipelineSource).toContain("await compileViewerSelfShadowShaders();");
+    expect(pipelineSource).toContain("while (true)");
     expect(pipelineSource).toContain("if (skipIfCompiling && viewerRenderCompileToken !== 0) {");
     expect(pipelineSource).toContain("viewerRenderCompileToken = token;");
     expect(pipelineSource).toContain("if (viewerRenderCompileToken === token) {");
@@ -192,6 +201,10 @@ describe("example viewer source", () => {
     expect(modelSource).toContain(
       "import { hideColliderHelpers, refreshDebugPanelState, restoreDebugMaterials, setOutlineHidden, showColliderHelpers } from \"./debug.js\";"
     );
+    expect(modelSource).toContain("await renderStillFrame({ compileShaders: isTslViewerPipeline() });");
+    expect(backgroundSource).toContain("await renderStillFrame({ compileShaders: isTslViewerPipeline() });");
+    expect(sceneSource).not.toContain("state.renderer?.render(state.scene, state.camera);");
+    expect(sceneSource).not.toContain("submitViewerRenderAsync");
     expect(modelSource).not.toContain("scheduleViewerShaderPrewarm");
     expect(backgroundSource).not.toContain("scheduleViewerShaderPrewarm");
     expect(modelSource).toContain(
@@ -1261,10 +1274,10 @@ describe("example viewer source", () => {
     expect(playbackSource).toContain("export function render() {");
     expect(playbackSource).toContain("evaluateRuntime();");
     expect(playbackSource).not.toContain("export async function render()");
-    expect(modelSource).toContain("await renderStillFrame();");
+    expect(modelSource).toContain("await renderStillFrame({ compileShaders: isTslViewerPipeline() });");
     expect(motionSource).toContain("await renderStillFrame();");
     expect(playbackSource).toContain("state.elapsedSeconds > 0 || hasCurrentMotion()");
-    expect(backgroundSource).toContain("await renderStillFrame();");
+    expect(backgroundSource).toContain("await renderStillFrame({ compileShaders: isTslViewerPipeline() });");
     expect(debugSource).toContain("async evaluateAt(seconds, options = {})");
     expect(debugSource).toContain("await renderStillFrame(options)");
     expect(debugSource).toContain("characters: state.characterModels.map(");

--- a/test/unit/webgpu/SelfShadowPass.test.ts
+++ b/test/unit/webgpu/SelfShadowPass.test.ts
@@ -15,6 +15,8 @@ describe("TSL dedicated self-shadow pass scaffold", () => {
     expect(source).toContain("const reversedDepth = renderer.reversedDepthBuffer === true;");
     expect(source).toContain("createMmdTslShadowVisibilityNode(light, depthTexture, { reversedDepth });");
     expect(source).toContain("setMode(mode: number): boolean;");
+    expect(source).toContain("compileAsync(renderer: THREE.WebGPURenderer, scene: THREE.Scene, light: THREE.DirectionalLight)");
+    expect(source).toContain("await currentRenderer.compileAsync(scene, prepared.shadowCamera);");
     expect(source).toContain("const nextMode = mode === 2 ? 2 : 1;");
     expect(source).toContain("shadowModeUniform.value = nextMode;");
     // T070-18: the pass used to bail out entirely under a reversed depth
@@ -39,7 +41,7 @@ describe("TSL dedicated self-shadow pass scaffold", () => {
     expect(source).toContain("THREE.RendererUtils.resetRendererAndSceneState");
     expect(source).toContain("THREE.RendererUtils.restoreRendererAndSceneState");
     expect(source).toContain("shadowCamera.layers.mask = 1 << MMD_SELF_SHADOW_LAYER;");
-    expect(source).toContain("currentRenderer.render(scene, shadowCamera);");
+    expect(source).toContain("currentRenderer.render(scene, prepared.shadowCamera);");
     expect(source).toContain("renderTarget.dispose();");
   });
 


### PR DESCRIPTION
## Summary

Prepare the v0.8.1 patch release for the TSL/WebGPU Viewer loading-stall fix.

The regression was caused by synchronous renderer re-entry from the Grid/Axis visibility handlers. On the TSL path this could trigger shader compilation, including dedicated self-shadow variants, on the main thread. This patch removes that direct render path and adds asynchronous, coalesced precompilation for the TSL color and self-shadow variants used during model/background loading and view toggles.

## Changes

- Make Grid/Axis toggles update visibility only; the normal animation render loop presents the change.
- Coalesce overlapping TSL compile requests.
- Precompile the TSL color variant with the final shadow-map state and the dedicated self-shadow variants asynchronously.
- Route model and background loading still-frame rendering through the async compile path.
- Keep the self-shadow compile hook internal; the public API surface is unchanged.
- Bump package/viewer metadata and changelog to 0.8.1.

## Validation

- `npm ci`
- `npm run lint`
- `npm test -- --run`: 82 files passed; 760 passed, 5 skipped
- `npm run build`
- `npm run check:fixtures`: 5/5
- `npm run check:fixtures:physics`: 5/5
- `npm run smoke:dist`
- `npm run smoke:types`
- `npm pack --dry-run --json`: @yohawing/three-mmd-loader@0.8.1, 232 files
- `npm run visual:smoke:generated-pmx`: 18/18
- `npm run visual:smoke:camera-light-vmd`: 4/4
- `npm run visual:smoke:self-shadow`: 13 rendered; all 4 self-shadow comparisons passed
- `npm run visual:smoke:viewer-background`
- `npm run visual:smoke:viewer-self-shadow`
- `git diff --check`

Note: `npm ci` reported 2 high-severity audit findings. No dependency changes are included in this release.

## Release boundary

This is intentionally a draft PR. Merge, tag `v0.8.1`, npm publish, GitHub Release, and Viewer deployment remain human-approved follow-up actions.