### PR TITLE
fix(physics): preserve dynamic-with-bone translation

### DIFF
--- a/src/physics/mmdAnimBullet.ts
+++ b/src/physics/mmdAnimBullet.ts
@@ -55,6 +55,7 @@ class MmdAnimBulletPhysicsBackend implements MmdPhysicsBackend {
   private readonly boneFromBody: Matrix4[] = [];
   private targetWorldMatrices = new Float32Array(0);
   private targetWorldUpdated = new Uint8Array(0);
+  private targetTranslationUpdated = new Uint8Array(0);
   private readonly scratchBone = new Matrix4();
   private readonly scratchBody = new Matrix4();
   private readonly scratchParent = new Matrix4();
@@ -158,6 +159,7 @@ class MmdAnimBulletPhysicsBackend implements MmdPhysicsBackend {
     const boneCount = Math.max(context.skeleton?.bones.length ?? 0, maxBoneIndex + 1);
     this.targetWorldMatrices = new Float32Array(boneCount * 16);
     this.targetWorldUpdated = new Uint8Array(boneCount);
+    this.targetTranslationUpdated = new Uint8Array(boneCount);
     const bodyPtr = this.module._malloc(RIGID_BODY_DESC_BYTES);
     this.module.refreshMemoryViews?.();
     try {
@@ -282,6 +284,7 @@ class MmdAnimBulletPhysicsBackend implements MmdPhysicsBackend {
     const output = context.output;
     if (!output) return 0;
     this.targetWorldUpdated.fill(0);
+    this.targetTranslationUpdated.fill(0);
 
     // Pass 1: read every dynamic body once and cache its target bone world pose.
     // Keeping this separate from local conversion makes parent lookup independent
@@ -308,6 +311,9 @@ class MmdAnimBulletPhysicsBackend implements MmdPhysicsBackend {
       writeNumeric16(this.targetWorldMatrices, worldOffset, this.scratchBone.elements);
       if (output.worldMatricesColumnMajor) writeNumeric16(output.worldMatricesColumnMajor, worldOffset, this.scratchBone.elements);
       this.targetWorldUpdated[boneIndex] = 1;
+      // Physics-with-bone keeps the animated local translation and only feeds
+      // the simulated rotation back to the bone.
+      this.targetTranslationUpdated[boneIndex] = this.bodyModes[i] === "dynamic" ? 1 : 0;
     }
 
     // Pass 2: convert each target world pose to the bone's local pose using the
@@ -329,7 +335,7 @@ class MmdAnimBulletPhysicsBackend implements MmdPhysicsBackend {
       }
       this.scratchParent.invert();
       this.scratchLocal.multiplyMatrices(this.scratchParent, this.scratchBone);
-      if (output.translations) {
+      if (output.translations && this.targetTranslationUpdated[boneIndex] !== 0) {
         const p = this.scratchLocal.elements;
         writeNumeric3(output.translations, boneIndex * 3, p[12] ?? 0, p[13] ?? 0, p[14] ?? 0);
       }

--- a/test/unit/physics/MmdAnimBulletBackend.test.ts
+++ b/test/unit/physics/MmdAnimBulletBackend.test.ts
@@ -246,6 +246,78 @@ describe("mmd-anim Bullet physics backend", () => {
     expect(result).toEqual({ simulated: false, updatedBoneCount: 2 });
   });
 
+  it("preserves dynamic-with-bone translation while applying simulated rotation", () => {
+    const fake = makeFakeModule();
+    const backend = createMmdAnimBulletPhysicsBackend(fake.module);
+    const inputWorld = new Float32Array(32);
+    for (let boneIndex = 0; boneIndex < 2; boneIndex += 1) {
+      const base = boneIndex * 16;
+      inputWorld[base] = inputWorld[base + 5] = inputWorld[base + 10] = inputWorld[base + 15] = 1;
+    }
+    inputWorld[12] = 1;
+    inputWorld[28] = 4;
+    const outputTranslations = new Float32Array([1, 2, 3, 4, 5, 6]);
+    const outputRotations = new Float32Array([0, 0, 0, 1, 0, 0, 0, 1]);
+    const updatedBoneIndices: number[] = [];
+    const simulatedRotation: [number, number, number, number] = [0, 0, Math.SQRT1_2, Math.SQRT1_2];
+    fake.setStepHook(() => {
+      const dynamic = fake.bodies[0];
+      const dynamicWithBone = fake.bodies[1];
+      if (dynamic) {
+        dynamic.position = [10, 20, 30];
+        dynamic.rotation = simulatedRotation;
+      }
+      if (dynamicWithBone) {
+        dynamicWithBone.position = [40, 50, 60];
+        dynamicWithBone.rotation = simulatedRotation;
+      }
+    });
+    const context = {
+      seconds: 0,
+      deltaSeconds: 1 / 60,
+      frame: 0,
+      frameRate: 30,
+      skeleton: {
+        bones: [
+          { index: 0, parentIndex: -1, restTranslation: [0, 0, 0] as const },
+          { index: 1, parentIndex: -1, restTranslation: [0, 0, 0] as const }
+        ]
+      },
+      rigidBodies: [
+        {
+          index: 0,
+          boneIndex: 0,
+          motionType: "dynamic" as const,
+          shape: { type: "sphere" as const, size: [0.5, 0.5, 0.5] as const },
+          localTranslation: [0, 0, 0] as const,
+          localRotation: [0, 0, 0, 1] as const,
+          mass: 1
+        },
+        {
+          index: 1,
+          boneIndex: 1,
+          motionType: "dynamicWithBone" as const,
+          shape: { type: "sphere" as const, size: [0.5, 0.5, 0.5] as const },
+          localTranslation: [0, 0, 0] as const,
+          localRotation: [0, 0, 0, 1] as const,
+          mass: 1
+        }
+      ],
+      joints: [],
+      inputWorldMatricesColumnMajor: inputWorld,
+      output: { translations: outputTranslations, rotations: outputRotations, updatedBoneIndices }
+    };
+
+    backend.step(context);
+    const result = backend.step({ ...context, seconds: 1 / 60, frame: 0.5 });
+
+    expect(Array.from(outputTranslations)).toEqual([10, 20, 30, 4, 5, 6]);
+    expect(Array.from(outputRotations.slice(0, 4))).toEqual(expectQuatCloseTo(simulatedRotation));
+    expect(Array.from(outputRotations.slice(4, 8))).toEqual(expectQuatCloseTo(simulatedRotation));
+    expect(updatedBoneIndices).toEqual([0, 1]);
+    expect(result).toEqual({ simulated: true, updatedBoneCount: 2 });
+  });
+
   it("re-seeds all bodies, re-pins static bodies, and reads dynamic outputs on reset", () => {
     const fake = makeFakeModule();
     const backend = createMmdAnimBulletPhysicsBackend(fake.module);
@@ -303,6 +375,7 @@ describe("mmd-anim Bullet physics backend", () => {
       14, 15, 16,
       17, 18, 19
     ]);
+    outputTranslations.set(inputTranslations);
     for (let boneIndex = 0; boneIndex < 3; boneIndex += 1) {
       const base = boneIndex * 16;
       inputWorld[base + 12] = inputTranslations[boneIndex * 3] ?? 0;


### PR DESCRIPTION
## Summary

- preserve the animation-provided local translation for `dynamicWithBone` rigid bodies
- continue feeding simulated translation back for `dynamic` rigid bodies
- apply simulated rotation and report updated bone indices for both dynamic modes
- add regression coverage for regular dynamic and physics-with-bone readback

Fixes #37.

## Verification

- `npm ci`
- `npm run lint`
- `npm run build`
- `npm test` (82 files, 761 passed, 5 skipped)
- `npm run check:fixtures` (5 checked, 0 failed)
- `npm run smoke:dist`

`npm run smoke:types` was also attempted locally on Windows with Node.js 26.5.0, but its `spawnSync("npm")` call fails with `ENOENT` because Windows exposes `npm.cmd`. The build's TypeScript compilation succeeds, and the upstream Linux Node.js 22/24 CI will run this smoke check in its supported environment.
