### PR TITLE
feat(physics): expose Bullet contact queries

### DIFF
--- a/src/physics/customBulletMmd.ts
+++ b/src/physics/customBulletMmd.ts
@@ -9,6 +9,8 @@ import type {
 } from "./index.js";
 import {
   createMmdAnimBulletPhysicsBackend,
+  type MmdAnimBulletContactPoint,
+  type MmdAnimBulletPhysicsBackend,
   type MmdAnimBulletModule
 } from "./mmdAnimBullet.js";
 
@@ -27,6 +29,11 @@ export interface CustomBulletMmdPhysicsBackendOptions {
 
 /** mmd-anim Bullet module exposed through the stable Custom Bullet API name. */
 export type CustomBulletMmdModule = MmdAnimBulletModule;
+
+export interface CustomBulletMmdPhysicsBackend extends MmdDirectBufferPhysicsBackend {
+  debugContactCount(): number;
+  debugPhysicsContacts(): readonly MmdAnimBulletContactPoint[];
+}
 
 type CustomBulletMmdFactory = (
   options?: { locateFile?: (path: string, prefix: string) => string }
@@ -71,14 +78,14 @@ export async function loadCustomBulletMmdModule(
 export function createCustomBulletMmdPhysicsBackend(
   module: CustomBulletMmdModule,
   options: CustomBulletMmdPhysicsBackendOptions = {}
-): MmdDirectBufferPhysicsBackend {
+): CustomBulletMmdPhysicsBackend {
   return new CustomBulletMmdCompatibilityBackend(module, options);
 }
 
-class CustomBulletMmdCompatibilityBackend implements MmdDirectBufferPhysicsBackend {
+class CustomBulletMmdCompatibilityBackend implements CustomBulletMmdPhysicsBackend {
   readonly name = "custom-bullet-mmd";
   readonly disabled = false;
-  private readonly backend;
+  private readonly backend: MmdAnimBulletPhysicsBackend;
   private stepBuffers: MmdPhysicsStepBuffers | undefined;
   private stepBufferBoneCount = -1;
 
@@ -126,5 +133,13 @@ class CustomBulletMmdCompatibilityBackend implements MmdDirectBufferPhysicsBacke
 
   diagnostics(): readonly MmdPhysicsDiagnostic[] {
     return this.backend.diagnostics?.() ?? [];
+  }
+
+  debugContactCount(): number {
+    return this.backend.debugContactCount();
+  }
+
+  debugPhysicsContacts(): readonly MmdAnimBulletContactPoint[] {
+    return this.backend.debugPhysicsContacts();
   }
 }

--- a/src/physics/index.ts
+++ b/src/physics/index.ts
@@ -4,9 +4,11 @@ export {
   loadCustomBulletMmdModule,
   resolveCustomBulletMmdScriptUrl,
   type CustomBulletMmdLoaderOptions,
+  type CustomBulletMmdPhysicsBackend,
   type CustomBulletMmdPhysicsBackendOptions,
   type CustomBulletMmdModule
 } from "./customBulletMmd.js";
+export type { MmdAnimBulletContactPoint } from "./mmdAnimBullet.js";
 export type MmdPhysicsDiagnosticLevel = "warning" | "error";
 
 export interface MmdPhysicsDiagnostic {

--- a/src/physics/mmdAnimBullet.ts
+++ b/src/physics/mmdAnimBullet.ts
@@ -31,17 +31,32 @@ export interface MmdAnimBulletModule {
   refreshMemoryViews?(): void;
 }
 
+export interface MmdAnimBulletContactPoint {
+  readonly rigidBodyIndexA: number;
+  readonly rigidBodyIndexB: number;
+  readonly distance: number;
+  readonly positionWorldOnA: readonly [number, number, number];
+  readonly positionWorldOnB: readonly [number, number, number];
+  readonly normalWorldOnB: readonly [number, number, number];
+}
+
+export interface MmdAnimBulletPhysicsBackend extends MmdPhysicsBackend {
+  debugContactCount(): number;
+  debugPhysicsContacts(): readonly MmdAnimBulletContactPoint[];
+}
+
 export function createMmdAnimBulletPhysicsBackend(
   module: MmdAnimBulletModule,
   options: { fixedTimeStep?: number; maxSubSteps?: number } = {}
-): MmdPhysicsBackend {
-  return new MmdAnimBulletPhysicsBackend(module, options);
+): MmdAnimBulletPhysicsBackend {
+  return new MmdAnimBulletPhysicsBackendImpl(module, options);
 }
 
 const RIGID_BODY_DESC_BYTES = 64;
 const JOINT_DESC_BYTES = 104;
+const CONTACT_POINT_BYTES = 48;
 
-class MmdAnimBulletPhysicsBackend implements MmdPhysicsBackend {
+class MmdAnimBulletPhysicsBackendImpl implements MmdAnimBulletPhysicsBackend {
   readonly name = "mmd-anim-bullet";
   readonly disabled = false;
   private world = 0;
@@ -68,17 +83,22 @@ class MmdAnimBulletPhysicsBackend implements MmdPhysicsBackend {
   private readonly outIndexPointer: number;
   private readonly transformPositionPointer: number;
   private readonly transformRotationPointer: number;
+  private readonly contactCountPointer: number;
+  private contactBufferPointer = 0;
+  private contactBufferCapacity = 0;
 
   constructor(private readonly module: MmdAnimBulletModule, private readonly options: { fixedTimeStep?: number; maxSubSteps?: number }) {
     this.outWorldPointer = module._malloc(4);
     this.outIndexPointer = module._malloc(4);
     this.transformPositionPointer = module._malloc(12);
     this.transformRotationPointer = module._malloc(16);
+    this.contactCountPointer = module._malloc(4);
     if (module._mmd_anim_bullet_world_create(this.outWorldPointer) !== 0) {
       module._free(this.outWorldPointer);
       module._free(this.outIndexPointer);
       module._free(this.transformPositionPointer);
       module._free(this.transformRotationPointer);
+      module._free(this.contactCountPointer);
       throw new Error("Failed to create mmd-anim Bullet world.");
     }
     this.module.refreshMemoryViews?.();
@@ -129,6 +149,8 @@ class MmdAnimBulletPhysicsBackend implements MmdPhysicsBackend {
     this.module._free(this.outIndexPointer);
     this.module._free(this.transformPositionPointer);
     this.module._free(this.transformRotationPointer);
+    this.module._free(this.contactCountPointer);
+    if (this.contactBufferPointer !== 0) this.module._free(this.contactBufferPointer);
     this.world = 0;
     this.disposedState = true;
   }
@@ -137,6 +159,47 @@ class MmdAnimBulletPhysicsBackend implements MmdPhysicsBackend {
     return this.disposedState
       ? [{ level: "warning", code: "PHYSICS_BACKEND_DISPOSED", message: "mmd-anim Bullet physics backend has been disposed." }]
       : [];
+  }
+
+  debugContactCount(): number {
+    const collect = this.module._mmd_anim_bullet_world_collect_contacts;
+    if (this.disposedState || !collect) return 0;
+    if (collect(this.world, 0, 0, this.contactCountPointer) !== 0) return 0;
+    this.module.refreshMemoryViews?.();
+    return this.module.HEAPU32?.[this.contactCountPointer >>> 2] ?? 0;
+  }
+
+  debugPhysicsContacts(): readonly MmdAnimBulletContactPoint[] {
+    const collect = this.module._mmd_anim_bullet_world_collect_contacts;
+    const count = this.debugContactCount();
+    if (!collect || count <= 0) return [];
+    if (count > this.contactBufferCapacity) {
+      if (this.contactBufferPointer !== 0) this.module._free(this.contactBufferPointer);
+      this.contactBufferPointer = this.module._malloc(count * CONTACT_POINT_BYTES);
+      this.contactBufferCapacity = count;
+    }
+    if (collect(this.world, this.contactBufferPointer, this.contactBufferCapacity, this.contactCountPointer) !== 0) return [];
+    this.module.refreshMemoryViews?.();
+    const heap = this.module.HEAPF32;
+    if (!heap) return [];
+    const heapI32 = new Int32Array(heap.buffer);
+    const written = Math.min(
+      this.module.HEAPU32?.[this.contactCountPointer >>> 2] ?? 0,
+      this.contactBufferCapacity
+    );
+    const contacts: MmdAnimBulletContactPoint[] = [];
+    for (let index = 0; index < written; index += 1) {
+      const base = (this.contactBufferPointer + index * CONTACT_POINT_BYTES) >>> 2;
+      contacts.push({
+        rigidBodyIndexA: heapI32[base] ?? -1,
+        rigidBodyIndexB: heapI32[base + 1] ?? -1,
+        distance: heap[base + 2] ?? 0,
+        positionWorldOnA: [heap[base + 3] ?? 0, heap[base + 4] ?? 0, heap[base + 5] ?? 0],
+        positionWorldOnB: [heap[base + 6] ?? 0, heap[base + 7] ?? 0, heap[base + 8] ?? 0],
+        normalWorldOnB: [heap[base + 9] ?? 0, heap[base + 10] ?? 0, heap[base + 11] ?? 0]
+      });
+    }
+    return contacts;
   }
 
   private ensureModel(context: MmdPhysicsStepContext): boolean {

--- a/test/unit/physics/MmdAnimBulletBackend.test.ts
+++ b/test/unit/physics/MmdAnimBulletBackend.test.ts
@@ -20,18 +20,21 @@ function makeFakeModule() {
   let destroyed = 0;
   let resetCount = 0;
   let settleCount = 0;
+  let contactCount = 0;
   let stepHook: (() => void) | undefined;
   const stepCalls: Array<[number, number, number]> = [];
   const setBodyCalls: Array<{ index: number; position: [number, number, number] }> = [];
   const bodies: Array<{ position: [number, number, number]; rotation: [number, number, number, number] }> = [];
   const rigidBodyRotations: Array<[number, number, number]> = [];
   const jointRotations: Array<[number, number, number]> = [];
+  const freedPointers: number[] = [];
+  const contactCalls: Array<{ outContacts: number; capacity: number }> = [];
   const module: MmdAnimBulletModule = {
     HEAPF32: heap,
     HEAPU8: heapU8,
     HEAPU32: heapU32,
     _malloc(size) { const pointer = next; next += Math.max(8, size); return pointer; },
-    _free() {},
+    _free(pointer) { freedPointers.push(pointer); },
     refreshMemoryViews() {},
     _mmd_anim_bullet_world_create(out) { heapU32[out >>> 2] = 64; created += 1; return 0; },
     _mmd_anim_bullet_world_destroy() { destroyed += 1; },
@@ -71,6 +74,21 @@ function makeFakeModule() {
       jointRotations.push([heap[index + 5] ?? 0, heap[index + 6] ?? 0, heap[index + 7] ?? 0]);
       heapU32[out >>> 2] = jointRotations.length - 1;
       return 0;
+    },
+    _mmd_anim_bullet_world_collect_contacts(_world, outContacts, capacity, outCount) {
+      contactCalls.push({ outContacts, capacity });
+      heapU32[outCount >>> 2] = contactCount;
+      if (outContacts !== 0 && capacity > 0) {
+        const heapI32 = new Int32Array(buffer);
+        const base = outContacts >>> 2;
+        heapI32[base] = 3;
+        heapI32[base + 1] = 7;
+        heap[base + 2] = -0.25;
+        heap.set([1, 2, 3], base + 3);
+        heap.set([4, 5, 6], base + 6);
+        heap.set([0, 1, 0], base + 9);
+      }
+      return 0;
     }
   };
   return {
@@ -80,15 +98,57 @@ function makeFakeModule() {
     jointRotations,
     stepCalls,
     setBodyCalls,
+    contactCalls,
+    freedPointers,
     get created() { return created; },
     get destroyed() { return destroyed; },
     get resetCount() { return resetCount; },
     get settleCount() { return settleCount; },
+    setContactCount(count: number) { contactCount = count; },
     setStepHook(hook: (() => void) | undefined) { stepHook = hook; }
   };
 }
 
 describe("mmd-anim Bullet physics backend", () => {
+  it("collects native Bullet contacts and forwards them through the compatibility backend", () => {
+    const fake = makeFakeModule();
+    const backend = createCustomBulletMmdPhysicsBackend(fake.module);
+    fake.setContactCount(1);
+
+    expect(backend.debugContactCount?.()).toBe(1);
+    expect(backend.debugPhysicsContacts?.()).toEqual([{
+      rigidBodyIndexA: 3,
+      rigidBodyIndexB: 7,
+      distance: -0.25,
+      positionWorldOnA: [1, 2, 3],
+      positionWorldOnB: [4, 5, 6],
+      normalWorldOnB: [0, 1, 0]
+    }]);
+    expect(backend.debugPhysicsContacts?.()).toHaveLength(1);
+    expect(fake.contactCalls).toEqual([
+      { outContacts: 0, capacity: 0 },
+      { outContacts: 0, capacity: 0 },
+      expect.objectContaining({ capacity: 1 }),
+      { outContacts: 0, capacity: 0 },
+      expect.objectContaining({ capacity: 1 })
+    ]);
+
+    const contactBufferPointer = fake.contactCalls[2]?.outContacts;
+    backend.dispose?.();
+    expect(fake.freedPointers).toContain(contactBufferPointer);
+    expect(backend.debugContactCount?.()).toBe(0);
+    expect(backend.debugPhysicsContacts?.()).toEqual([]);
+  });
+
+  it("returns no contacts when the native module does not expose contact collection", () => {
+    const fake = makeFakeModule();
+    delete fake.module._mmd_anim_bullet_world_collect_contacts;
+    const backend = createMmdAnimBulletPhysicsBackend(fake.module);
+
+    expect(backend.debugContactCount?.()).toBe(0);
+    expect(backend.debugPhysicsContacts?.()).toEqual([]);
+  });
+
   it("uploads rotations in the native Bullet ZYX encoding", () => {
     const fake = makeFakeModule();
     const backend = createMmdAnimBulletPhysicsBackend(fake.module);


### PR DESCRIPTION
## Summary

- expose count-only and detailed contact queries from the mmd-anim Bullet backend
- decode the existing 48-byte native contact ABI without changing or rebuilding WASM
- forward contact queries through the stable Custom Bullet compatibility backend
- allocate contact storage lazily, reuse it across queries, and release it on dispose
- return safe empty results when the optional native contact export is unavailable or the backend is disposed
- export the contact point and backend types from the public physics entry

Fixes #39.

## Verification

- `npm run lint`
- `npm run build`
- `npm test` (82 files, 762 passed, 5 skipped)
- `npm run check:fixtures` (5 checked, 0 failed)
- `npm run smoke:dist`

`npm run smoke:types` is not runnable locally on Windows because its `spawnSync("npm")` call does not resolve `npm.cmd`. The build's TypeScript compilation and generated declarations pass, and upstream Linux Node.js 22/24 CI will run the consumer smoke check.
